### PR TITLE
updated docker exec commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ docker-compose up --build -d
 
 ```bash
 # run a bash shell in the container
-docker exec -it <container-name> /bin/bash
+docker-compose exec db bash
 
 # in container now
 psql -U postgres -d ccbc
@@ -111,17 +111,20 @@ SELECT * FROM <table-name>;
 TypeScript backend and frontend:
 ```bash
 # linting & formatting warnings only
-docker exec -it <container-name> /bin/bash -c "yarn lint"
+docker-compose exec ts-backend yarn lint  # backend
+docker-compose exec frontend yarn lint    # frontend
 
 # linting with fix & formatting
-docker exec -it <container-name> /bin/bash -c "yarn fix"
+docker-compose exec <service-name> yarn fix
+# service-name: ts-backend or frontend
 ```
 
 ### Running Tests
 
 TypeScript backend and frontend:
 ```bash
-docker exec -it <container-name> /bin/bash -c "yarn test"
+docker-compose exec <service-name> yarn test
+# service-name: ts-backend or frontend
 ```
 
 ### Running Migrations
@@ -140,7 +143,7 @@ cd backend/typescript
 # get container name
 $ docker ps
 # run a bash shell
-$ docker exec -it ccbc_ts-backend_1 /bin/bash  
+$ docker-compose exec ts-backend bash  
 ```
 
 4. Ensure you have migration files in the migrations folder


### PR DESCRIPTION
## Notion ticket link
None

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Replaced docker exec commands with equivalent compose commands. Docker will now find container mapped to specific service name (ie. ts-backend) rather than using the container name.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test all these commands after running `docker-compose up -d`


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Make sure all the commands works as expected


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
