### PR TITLE
add role auth middleware to review and tag service endpoints

### DIFF
--- a/backend/typescript/rest/reviewRoutes.ts
+++ b/backend/typescript/rest/reviewRoutes.ts
@@ -9,73 +9,91 @@ import {
 import { getErrorMessage, sendErrorResponse } from "../utilities/errorResponse";
 import sendResponseByMimeType from "../utilities/responseUtil";
 import reviewRequestDtoValidator from "../middlewares/validators/reviewValidators";
+import { isAuthorizedByRole } from "../middlewares/auth";
 
 const reviewRouter: Router = Router();
 const reviewService: IReviewService = new ReviewService();
 
-reviewRouter.post("/", reviewRequestDtoValidator, async (req, res) => {
-  const contentType = req.headers["content-type"];
-  try {
-    const newReview = await reviewService.createReview({
-      body: req.body.body,
-      byline: req.body.byline,
-      featured: req.body.featured,
-      /*
-       *@TODO: uncomment when christine changes are merged
-       *createdBy: req.body.createdBy,
-       */
-      books: req.body.books as BookRequest[],
-      tags: req.body.tags as Tag[],
-      publishedAt: req.body.publishedAt,
-    });
-    await sendResponseByMimeType<ReviewResponseDTO>(
-      res,
-      200,
-      contentType,
-      newReview,
-    );
-  } catch (e: unknown) {
-    sendErrorResponse(e, res);
-  }
-});
+reviewRouter.post(
+  "/",
+  isAuthorizedByRole(new Set(["Admin"])),
+  reviewRequestDtoValidator,
+  async (req, res) => {
+    const contentType = req.headers["content-type"];
+    try {
+      const newReview = await reviewService.createReview({
+        body: req.body.body,
+        byline: req.body.byline,
+        featured: req.body.featured,
+        /*
+         *@TODO: uncomment when christine changes are merged
+         *createdBy: req.body.createdBy,
+         */
+        books: req.body.books as BookRequest[],
+        tags: req.body.tags as Tag[],
+        publishedAt: req.body.publishedAt,
+      });
+      await sendResponseByMimeType<ReviewResponseDTO>(
+        res,
+        200,
+        contentType,
+        newReview,
+      );
+    } catch (e: unknown) {
+      sendErrorResponse(e, res);
+    }
+  },
+);
 
-reviewRouter.get("/:id", async (req, res) => {
-  const { id } = req.params;
-  try {
-    const review = await reviewService.getReview(id);
-    res.status(200).json(review);
-  } catch (e: unknown) {
-    sendErrorResponse(e, res);
-  }
-});
+reviewRouter.get(
+  "/:id",
+  isAuthorizedByRole(new Set(["Admin", "Subscriber", "Author"])),
+  async (req, res) => {
+    const { id } = req.params;
+    try {
+      const review = await reviewService.getReview(id);
+      res.status(200).json(review);
+    } catch (e: unknown) {
+      sendErrorResponse(e, res);
+    }
+  },
+);
 
-reviewRouter.get("/", async (req, res) => {
-  const contentType = req.headers["content-type"];
-  try {
-    const reviews = await reviewService.getReviews();
-    await sendResponseByMimeType<ReviewResponseDTO[]>(
-      res,
-      200,
-      contentType,
-      reviews,
-    );
-  } catch (e: unknown) {
-    await sendResponseByMimeType(res, 500, contentType, [
-      {
-        error: getErrorMessage(e),
-      },
-    ]);
-  }
-});
+reviewRouter.get(
+  "/",
+  isAuthorizedByRole(new Set(["Admin", "Subscriber", "Author"])),
+  async (req, res) => {
+    const contentType = req.headers["content-type"];
+    try {
+      const reviews = await reviewService.getReviews();
+      await sendResponseByMimeType<ReviewResponseDTO[]>(
+        res,
+        200,
+        contentType,
+        reviews,
+      );
+    } catch (e: unknown) {
+      await sendResponseByMimeType(res, 500, contentType, [
+        {
+          error: getErrorMessage(e),
+        },
+      ]);
+    }
+  },
+);
 
-reviewRouter.delete("/:id", async (req, res) => {
-  const { id } = req.params;
-  try {
-    await reviewService.deleteReview(id);
-    res.status(204).send();
-  } catch (e: unknown) {
-    sendErrorResponse(e, res);
-  }
-});
+reviewRouter.delete(
+  "/:id",
+  isAuthorizedByRole(new Set(["Admin"])),
+  async (req, res) => {
+    const { id } = req.params;
+    try {
+      await reviewService.deleteReview(id);
+      res.status(204).send();
+    } catch (e: unknown) {
+      sendErrorResponse(e, res);
+    }
+  },
+);
 
 export default reviewRouter;

--- a/backend/typescript/rest/tagRoutes.ts
+++ b/backend/typescript/rest/tagRoutes.ts
@@ -3,32 +3,41 @@ import sendResponseByMimeType from "../utilities/responseUtil";
 import TagService from "../services/implementations/tagService";
 import { ITagService } from "../services/interfaces/ITagService";
 import { getErrorMessage, sendErrorResponse } from "../utilities/errorResponse";
+import { isAuthorizedByRole } from "../middlewares/auth";
 
 const tagRouter: Router = Router();
 const tagService: ITagService = new TagService();
 
-tagRouter.get("/", async (req, res) => {
-  const contentType = req.headers["content-type"];
-  try {
-    const tags = await tagService.getTags();
-    await sendResponseByMimeType(res, 200, contentType, tags);
-  } catch (e: unknown) {
-    await sendResponseByMimeType(res, 500, contentType, [
-      {
-        error: getErrorMessage(e),
-      },
-    ]);
-  }
-});
+tagRouter.get(
+  "/",
+  isAuthorizedByRole(new Set(["Admin", "Subscriber", "Author"])),
+  async (req, res) => {
+    const contentType = req.headers["content-type"];
+    try {
+      const tags = await tagService.getTags();
+      await sendResponseByMimeType(res, 200, contentType, tags);
+    } catch (e: unknown) {
+      await sendResponseByMimeType(res, 500, contentType, [
+        {
+          error: getErrorMessage(e),
+        },
+      ]);
+    }
+  },
+);
 
-tagRouter.delete("/:id", async (req, res) => {
-  const { id } = req.params;
-  try {
-    await tagService.deleteTag(id);
-    res.status(204).send();
-  } catch (e: unknown) {
-    sendErrorResponse(e, res);
-  }
-});
+tagRouter.delete(
+  "/:id",
+  isAuthorizedByRole(new Set(["Admin"])),
+  async (req, res) => {
+    const { id } = req.params;
+    try {
+      await tagService.deleteTag(id);
+      res.status(204).send();
+    } catch (e: unknown) {
+      sendErrorResponse(e, res);
+    }
+  },
+);
 
 export default tagRouter;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Review Service: Add Middleware](https://www.notion.so/uwblueprintexecs/Review-Service-Add-Middleware-92f6804588e2492083943261fd121413)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added `isAuthorizedByRole` middleware to review and tag endpoints
* Modification of reviews or tags (create, update, delete) requires "Admin" role
* Other endpoints require any ("Admin", "Subscriber", "Author") role


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Make requests to any review or tag endpoint (e.g. `POST /reviews/`, `GET /tags/`) with/without a valid access token


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
