### PR TITLE
Fix getting auth token without page refresh

### DIFF
--- a/frontend/src/APIClients/ReviewAPIClient.ts
+++ b/frontend/src/APIClients/ReviewAPIClient.ts
@@ -1,5 +1,5 @@
-import { BEARER_TOKEN } from "../constants/AuthConstants";
 import { ReviewRequest, ReviewResponse } from "../types/ReviewTypes";
+import { getBearerToken } from "../utils/AuthUtils";
 import baseAPIClient from "./BaseAPIClient";
 
 /*
@@ -8,7 +8,7 @@ import baseAPIClient from "./BaseAPIClient";
 const getReviews = async (): Promise<ReviewResponse[]> => {
   try {
     const { data } = await baseAPIClient.get("/reviews", {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
     return data;
   } catch (error: unknown) {
@@ -27,7 +27,7 @@ const publishReview = async (
   try {
     const { data } = await baseAPIClient.post("/reviews", review, {
       headers: {
-        Authorization: BEARER_TOKEN,
+        Authorization: getBearerToken(),
         "Content-Type": "application/json",
       },
     });
@@ -43,7 +43,7 @@ const publishReview = async (
 const deleteReviewById = async (id: string): Promise<ReviewResponse> => {
   try {
     const { data } = await baseAPIClient.delete(`/reviews/${id.toString()}`, {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
     return data;
   } catch (error) {
@@ -61,9 +61,9 @@ const getReviewById = async (id: string): Promise<ReviewResponse> => {
   // TODO: catch error
   const requestRoute = `/reviews/${id}`;
   const { data } = await baseAPIClient.get(requestRoute, {
-    headers: { Authorization: BEARER_TOKEN },
+    headers: { Authorization: getBearerToken() },
   });
   return data;
 };
-
+// test
 export default { getReviews, publishReview, deleteReviewById, getReviewById };

--- a/frontend/src/APIClients/ReviewAPIClient.ts
+++ b/frontend/src/APIClients/ReviewAPIClient.ts
@@ -65,5 +65,5 @@ const getReviewById = async (id: string): Promise<ReviewResponse> => {
   });
   return data;
 };
-// test
+
 export default { getReviews, publishReview, deleteReviewById, getReviewById };

--- a/frontend/src/APIClients/TagAPIClient.ts
+++ b/frontend/src/APIClients/TagAPIClient.ts
@@ -1,11 +1,11 @@
-import { BEARER_TOKEN } from "../constants/AuthConstants";
 import { TagResponse } from "../types/TagTypes";
+import { getBearerToken } from "../utils/AuthUtils";
 import baseAPIClient from "./BaseAPIClient";
 
 const getTags = async (): Promise<TagResponse[]> => {
   try {
     const { data } = await baseAPIClient.get("/tags", {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
 
     // For testing comment out above and use below:
@@ -25,7 +25,7 @@ const getTags = async (): Promise<TagResponse[]> => {
 const deleteTagById = async (id: string): Promise<TagResponse> => {
   try {
     const { data } = await baseAPIClient.delete(`/tags/${id.toString()}`, {
-      headers: { Authorization: BEARER_TOKEN },
+      headers: { Authorization: getBearerToken() },
     });
     return data;
   } catch (error) {

--- a/frontend/src/constants/AuthConstants.ts
+++ b/frontend/src/constants/AuthConstants.ts
@@ -1,16 +1,9 @@
-import { getLocalStorageObjProperty } from "../utils/LocalStorageUtils";
-
 const AUTHENTICATED_USER_KEY = `${window.location.hostname}:AUTHENTICATED_USER`;
 
 const SETUP_PASSWORD_MODE = "setup-password";
 const VERIFY_USER_MODE = "verify-user";
 const RESET_PASSWORD_MODE = "reset-password";
 const RECOVER_EMAIL_MODE = "recover-email";
-
-export const BEARER_TOKEN = `Bearer ${getLocalStorageObjProperty(
-  AUTHENTICATED_USER_KEY,
-  "accessToken",
-)}`;
 
 export {
   AUTHENTICATED_USER_KEY,

--- a/frontend/src/utils/AuthUtils.ts
+++ b/frontend/src/utils/AuthUtils.ts
@@ -1,6 +1,18 @@
+import { getLocalStorageObjProperty } from "./LocalStorageUtils";
+
 const validateEmail = (email: string): boolean => {
   const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return regex.test(email);
 };
 
-export default { validateEmail };
+/**
+ * Fetches the auth token from local storage
+ * @returns The token value, prepended by 'Bearer'
+ */
+export const getBearerToken = (): string => {
+  const key = `${window.location.hostname}:AUTHENTICATED_USER`;
+  const token = `Bearer ${getLocalStorageObjProperty(key, "accessToken")}`;
+  return token;
+};
+
+export default { validateEmail, getBearerToken };

--- a/frontend/src/utils/AuthUtils.ts
+++ b/frontend/src/utils/AuthUtils.ts
@@ -1,3 +1,4 @@
+import { AUTHENTICATED_USER_KEY } from "../constants/AuthConstants";
 import { getLocalStorageObjProperty } from "./LocalStorageUtils";
 
 const validateEmail = (email: string): boolean => {
@@ -10,8 +11,10 @@ const validateEmail = (email: string): boolean => {
  * @returns The token value, prepended by 'Bearer'
  */
 export const getBearerToken = (): string => {
-  const key = `${window.location.hostname}:AUTHENTICATED_USER`;
-  const token = `Bearer ${getLocalStorageObjProperty(key, "accessToken")}`;
+  const token = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
   return token;
 };
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/16fb020b93f641c8b384f76a1b3c769e?v=aedc8d99cd8b437cb556ece10f3c0e3c&p=f65b6bd2d905433a97458d1bc3b9cf05)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Originally, the bearer token was stored as a const, which did not get updated from the local storage without a page reload
* Created a function to programatically fetch the token from local storage on every request


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Clear local storage or open a new incognito window
2. Navigate to login page, login as usual
3. Open inspect console/developer tools
4. Navigate to the admin dashboard and ensure it gets populated without a page refresh


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Code correctness
* Is `AuthUtils.ts` a good place to put this function?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
