### PR TITLE
Fix bug where price in Book Modal is NaN

### DIFF
--- a/frontend/src/components/pages/CreateReview/BookModal.tsx
+++ b/frontend/src/components/pages/CreateReview/BookModal.tsx
@@ -137,7 +137,7 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
 
       const bookFormat = book.formats[0];
       setFormat(bookFormat.format);
-      setPrice(parseInt(bookFormat.price.substring(1), 10));
+      setPrice(parseInt(bookFormat.price, 10));
       setIsbn(bookFormat.isbn);
       const bookPublisher = book.publishers[0];
       setPublisher(bookPublisher.fullName);


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/16fb020b93f641c8b384f76a1b3c769e?v=aedc8d99cd8b437cb556ece10f3c0e3c&p=4e4dfe6d1ea342ac9679c151e8c9a3ba


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* The price string was being spliced for some reason, removed this


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to the create review page, open the "add book" modal
2. Fill in all fields, enter an integer price
3. Click save
4. Click the book you just added to re-open the Book Modal
5. You should see the price you entered
6. Publish the review and come back to edit it
7. Open an existing book's modal, you should see the book's price


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Why were we taking the substring in the first place?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
