### PR TITLE
[Hotfix] Disable Review Submission Without Books Entry

### DIFF
--- a/frontend/src/components/pages/CreateReview/CreateReview.tsx
+++ b/frontend/src/components/pages/CreateReview/CreateReview.tsx
@@ -70,7 +70,7 @@ const CreateReview = ({ id }: CreateReviewProps): React.ReactElement => {
   const [reviewerByline, setReviewerByline] = useState("");
 
   const cannotPublish =
-    review === "" && reviewerByline === "" && books.length === 0;
+    review === "" || reviewerByline === "" || books.length === 0;
 
   const [reviewError, setReviewError] = useState(false);
   const [bylineError, setBylineError] = useState(false);

--- a/frontend/src/components/pages/CreateReview/CreateReview.tsx
+++ b/frontend/src/components/pages/CreateReview/CreateReview.tsx
@@ -69,7 +69,8 @@ const CreateReview = ({ id }: CreateReviewProps): React.ReactElement => {
   const [featured, setFeatured] = useState("0");
   const [reviewerByline, setReviewerByline] = useState("");
 
-  const cannotPublish = review === "" && reviewerByline === "";
+  const cannotPublish =
+    review === "" && reviewerByline === "" && books.length === 0;
 
   const [reviewError, setReviewError] = useState(false);
   const [bylineError, setBylineError] = useState(false);


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Can add review with no books (Frontend)](https://www.notion.so/uwblueprintexecs/Can-add-review-with-no-books-Frontend-4b95a7be3b03480c827233e83da75b64)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a check to disable the submit review button if the review doesn't have any books associated with it


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to `/create-review`
2. Delete the book present
3. Verify that the Publish button is disabled 


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have run docker-compose up and my project compiled
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
