### PR TITLE
Age range field bug fix

### DIFF
--- a/frontend/src/components/pages/CreateReview/AddNumberInput.tsx
+++ b/frontend/src/components/pages/CreateReview/AddNumberInput.tsx
@@ -13,7 +13,7 @@ type AddNumberInputProps = {
   mb?: number;
   minNum: number;
   maxNum: number;
-  numberInputFieldValue: number;
+  numberInputFieldValue: number | "";
   setNumberField: (n: number) => void;
 };
 

--- a/frontend/src/components/pages/CreateReview/BookModal.tsx
+++ b/frontend/src/components/pages/CreateReview/BookModal.tsx
@@ -170,8 +170,8 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
     price > 0 &&
     coverImage !== "" &&
     // genre !== "" &&
-    minAge > 0 &&
-    maxAge > 0 &&
+    minAge >= 0 &&
+    maxAge >= 0 &&
     maxAge >= minAge &&
     isEmptyOrValidISBN;
 
@@ -381,7 +381,7 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
                     <AddNumberInput
                       placeholder="Min Age"
                       mb={0}
-                      numberInputFieldValue={minAge}
+                      numberInputFieldValue={minAge >= 0 ? minAge : ""}
                       setNumberField={setMinAge}
                       minNum={kMinAge}
                       maxNum={kMaxAge}
@@ -389,7 +389,7 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
                     <AddNumberInput
                       placeholder="Max Age"
                       mb={0}
-                      numberInputFieldValue={maxAge}
+                      numberInputFieldValue={maxAge >= 0 ? maxAge : ""}
                       setNumberField={setMaxAge}
                       minNum={minAge}
                       maxNum={kMaxAge}


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Age range field ](https://www.notion.so/uwblueprintexecs/Age-range-field-e27580186fc74348a7408eb7cf3c4a53)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Voted for better UX design. Now upon deleting a number field we can see it as empty instead of NaN


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to the Admin Dashboard 
2. Either click “Add Review” or edit an existing review
3. Either click “Add Book”, or if editing, click an existing book
4. Add an audience age range of any value then delete it (for both min and max), min and max fields should be empty instead of displaying NaN  
5. Fill in all other required fields, put 0 as the min audience age range, some value >0 as the max audience range
6. Try to click save, you should be able to save


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* The Modal works as intended, can have a min age of 0, and do not see NaN display upon deletion of age. Can not submit form with an empty age


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
