### PR TITLE
Fix bug with preview modal header

### DIFF
--- a/frontend/src/components/PreviewReview/PreviewReviewModal.tsx
+++ b/frontend/src/components/PreviewReview/PreviewReviewModal.tsx
@@ -44,7 +44,14 @@ const PreviewReviewModal = ({
     }
     return "";
   };
-
+  // modalState returns "Published" if published_at has a value and "Draft" if it is null
+  const modalState = () => {
+    if (review.publishedAt==null) {
+      return "Draft";
+    }
+    return "Published";
+  };
+  // below needs to be changed
   return (
     <>
       <Modal isOpen={isOpen} onClose={onClose} size="2xl" isCentered>
@@ -54,7 +61,7 @@ const PreviewReviewModal = ({
             <HStack spacing={150} fontSize={14}>
               <HStack>
                 <Text fontWeight={600}>Previewing:</Text>
-                <Text fontWeight={400}>Draft</Text>
+                <Text fontWeight={400}>{modalState()}</Text>  
               </HStack>
               <Text fontWeight={600}>{modalTitle()}</Text>
             </HStack>

--- a/frontend/src/components/PreviewReview/PreviewReviewModal.tsx
+++ b/frontend/src/components/PreviewReview/PreviewReviewModal.tsx
@@ -46,7 +46,7 @@ const PreviewReviewModal = ({
   };
   // modalState returns "Published" if published_at has a value and "Draft" if it is null
   const modalState = () => {
-    if (review.publishedAt==null) {
+    if (review.publishedAt == null) {
       return "Draft";
     }
     return "Published";
@@ -61,7 +61,7 @@ const PreviewReviewModal = ({
             <HStack spacing={150} fontSize={14}>
               <HStack>
                 <Text fontWeight={600}>Previewing:</Text>
-                <Text fontWeight={400}>{modalState()}</Text>  
+                <Text fontWeight={400}>{modalState()}</Text>
               </HStack>
               <Text fontWeight={600}>{modalTitle()}</Text>
             </HStack>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Preview displays “draft” for published reviews](https://www.notion.so/uwblueprintexecs/Preview-displays-draft-for-published-reviews-d736f8cd836b44af8ef54923f8d96e93)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
*  Checked if the published_at data field for Review is undefined or null
* If undefined or null, the preview Modal header displays "draft"
* Otherwise, displays "published"


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to the admin dashboard
2. If a book review does not exist, publish one 
3. click the preview button (eye), in the top left corner: "Previewing" should say published if the review is published
4. Since draft reviews cannot be previewed yet, change the data field for published_at to null and tests that the book review says "Draft"


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
