### PR TITLE
fixed ISB to include numbers and dashes

### DIFF
--- a/frontend/src/components/pages/CreateReview/AddStringInput.tsx
+++ b/frontend/src/components/pages/CreateReview/AddStringInput.tsx
@@ -14,6 +14,7 @@ type AddStringInputProps = {
   setInputField: (s: string) => void;
   isInvalid?: boolean;
   errorMessage?: string;
+  regexPattern?: RegExp;
 };
 
 /**
@@ -33,9 +34,12 @@ const AddStringInput = ({
   setInputField,
   isInvalid,
   errorMessage,
+  regexPattern,
 }: AddStringInputProps): React.ReactElement => {
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputField(e.target.value);
+    if (!regexPattern || regexPattern?.test(e.target.value)) {
+      setInputField(e.target.value);
+    }
   };
 
   return (

--- a/frontend/src/components/pages/CreateReview/BookModal.tsx
+++ b/frontend/src/components/pages/CreateReview/BookModal.tsx
@@ -99,6 +99,7 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
    * Calls clearBookData() whenever modal is closed,
    * otherwise calls setBookData if currBook is not null
    */
+
   useEffect(() => {
     /** Clears book data */
     const clearBookData = () => {
@@ -153,12 +154,9 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
     }
   }, [isOpen, currBook, setCurrBook]);
 
-  /** Ensure that ISBN is valid or an empty field */
   const isEmptyOrValidISBN =
     isbn === "" || // necessary to ensure that empty form won't error
-    (isbn.length === 13 &&
-      !Number.isNaN(Number(isbn)) &&
-      Number.isInteger(Number(isbn)));
+    /^([0-9]|[-])*$/.test(isbn);
 
   /** Check that all required modal fields are properly filled out */
   const hasRequired =
@@ -343,6 +341,7 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
                     setInputField={setIsbn}
                     isInvalid={!isEmptyOrValidISBN}
                     errorMessage="Invalid ISBN format."
+                    regexPattern={/^([0-9]|[-])*$/}
                   />
                   <FormControl id="price" isRequired width="45%">
                     <FormLabel mb={2}>Price</FormLabel>

--- a/frontend/src/components/pages/CreateReview/BookModal.tsx
+++ b/frontend/src/components/pages/CreateReview/BookModal.tsx
@@ -99,7 +99,6 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
    * Calls clearBookData() whenever modal is closed,
    * otherwise calls setBookData if currBook is not null
    */
-
   useEffect(() => {
     /** Clears book data */
     const clearBookData = () => {
@@ -154,6 +153,7 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
     }
   }, [isOpen, currBook, setCurrBook]);
 
+  /** Ensure that ISBN is valid or an empty field */
   const isEmptyOrValidISBN =
     isbn === "" || // necessary to ensure that empty form won't error
     /^([0-9]|[-])*$/.test(isbn);


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Allow dashes in the ISBN field](https://www.notion.so/uwblueprintexecs/Allow-dashes-in-the-ISBN-field-0ac9ac6270684d19b8e6b0639c4b587e)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* 
ISB can now have only numbers and dashes with no 13 digit limit and can not have letters.
Added a regex pattern field to the form so that in the future we can use regex to filter out inputs appearing on the form

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Admin Dashboard -> Create review 
2. Add a book
3. Play with the isb field, attempt adding dashes and numbers (should work),  attempt to add letters or other symbols (should not work)
4. Should be able to fully publish given the isb field is filled properly (and so are the other fields)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
The ISB field working as intended and filtering unwanted input


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
