### PR TITLE
[Bug] Publish Crashes when Adding an Empty Illustrator and/or Translator

### DIFF
--- a/backend/typescript/services/implementations/reviewService.ts
+++ b/backend/typescript/services/implementations/reviewService.ts
@@ -134,7 +134,7 @@ class ReviewService implements IReviewService {
         illustrator: book.illustrator || null,
         translator: book.translator || null,
         formats: book.formats,
-        age_range: [book.minAge, book.maxAge],
+        age_range: [{ value: book.minAge, inclusive: true }, { value: book.maxAge, inclusive: true }],
       },
       { transaction: t },
     );

--- a/backend/typescript/services/implementations/reviewService.ts
+++ b/backend/typescript/services/implementations/reviewService.ts
@@ -134,7 +134,10 @@ class ReviewService implements IReviewService {
         illustrator: book.illustrator || null,
         translator: book.translator || null,
         formats: book.formats,
-        age_range: [{ value: book.minAge, inclusive: true }, { value: book.maxAge, inclusive: true }],
+        age_range: [
+          { value: book.minAge, inclusive: true },
+          { value: book.maxAge, inclusive: true },
+        ],
       },
       { transaction: t },
     );


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Publish Crashes when Adding an Empty Illustrator and/or Translator](https://www.notion.so/uwblueprintexecs/Publish-Crashes-when-Adding-an-Empty-Illustrator-and-or-Translator-443728d5526548a39227926eb6100ded)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* turns out it wasn't a problem with adding empty illustrators/translators, but a problem with if the minimum age and maximum age are the same
* this is because we create a Range object composed of [minimum age, maximum age] and by default, it's set to [) (inclusive min, exlusive max) https://sequelize.org/docs/v6/other-topics/other-data-types/ 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. create a review with a new book with empty illustrator/translator and min/max age different and publish it
2. create a review with a new book with empty illustrator/translator and SAME min/max age and publish it
3. create a review with a new book with no illustrators/translators and SAME min/max age and publish it
4. check that old reviews can still be reviewed as well


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
