### PR TITLE
[Bug] fix bug with misordered books in preview modal

### DIFF
--- a/frontend/src/components/PreviewReview/PreviewReview.tsx
+++ b/frontend/src/components/PreviewReview/PreviewReview.tsx
@@ -32,6 +32,14 @@ const PreviewReview = ({
 }: PreviewReviewProps): React.ReactElement => {
   const [currentBook, setCurrentBook] = useState<number>(0);
 
+  // sort books based on series order
+  review.books.sort((a, b) => {
+    const seriesOrderA = a.seriesOrder ? a.seriesOrder : 0;
+    const seriesOrderB = b.seriesOrder ? b.seriesOrder : 0;
+
+    return seriesOrderA - seriesOrderB;
+  });
+
   const handleLeftClick = () => {
     if (currentBook > 0) {
       setCurrentBook(currentBook - 1);


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Books in Review are misordered](https://www.notion.so/uwblueprintexecs/Books-in-Review-are-misordered-e6ddddcd2dfd472f999bd1f41ca987f0)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Sorted the book array according to their series order


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
Add a Review with multiple Books, and set different `seriesOrder` s for each Book (try setting it randomly for each book, so its not in order chronologically). On the Add Review Page, the Books should be sorted by their series order. Publish the review, open the preview component, and check that:

1. The books are sorted according to their order in the series


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* checking that the books show up in correct order based on their series number no matter what order they were added in


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
