### PR TITLE
[Feat] Grid of Reviews Component

### DIFF
--- a/frontend/src/components/common/CircleBadge.tsx
+++ b/frontend/src/components/common/CircleBadge.tsx
@@ -1,0 +1,27 @@
+import { Circle } from "@chakra-ui/react";
+import React from "react";
+
+const CircleBadge = ({ count }: { count: number }): React.ReactElement => {
+  return (
+    <Circle
+      bgColor="white"
+      size={["50px"]}
+      position="absolute"
+      top="-20px"
+      right="-10px"
+    >
+      <Circle
+        color="white"
+        fontSize="1rem"
+        fontWeight="bold"
+        bgColor="#110A23"
+        borderRadius="100px"
+        size={["40px"]}
+      >
+        +{count}
+      </Circle>
+    </Circle>
+  );
+};
+
+export default CircleBadge;

--- a/frontend/src/components/common/CircleBadge.tsx
+++ b/frontend/src/components/common/CircleBadge.tsx
@@ -9,6 +9,7 @@ const CircleBadge = ({ count }: { count: number }): React.ReactElement => {
       position="absolute"
       top="-20px"
       right="-10px"
+      zIndex={10}
     >
       <Circle
         color="white"

--- a/frontend/src/components/common/CircleBadge.tsx
+++ b/frontend/src/components/common/CircleBadge.tsx
@@ -5,18 +5,18 @@ const CircleBadge = ({ count }: { count: number }): React.ReactElement => {
   return (
     <Circle
       bgColor="white"
-      size={["50px"]}
+      size={["42px", "42px", "50px"]}
       position="absolute"
       top="-20px"
       right="-10px"
     >
       <Circle
         color="white"
-        fontSize="1rem"
+        fontSize={["0.8rem", "0.8rem", "1rem"]}
         fontWeight="bold"
         bgColor="#110A23"
         borderRadius="100px"
-        size={["40px"]}
+        size={["34px", "34px", "40px"]}
       >
         +{count}
       </Circle>

--- a/frontend/src/components/pages/MockSearch/MockSearchPage.tsx
+++ b/frontend/src/components/pages/MockSearch/MockSearchPage.tsx
@@ -1,51 +1,9 @@
-import { Box } from "@chakra-ui/react";
 import React from "react";
 
-import { Author, Book } from "../../../types/BookTypes";
-import mockReviews from "./mockReviews";
-import ReviewThumbnail from "./ReviewThumbnail";
+import ReviewsGrid from "./ReviewsGrid";
 
 const MockSearchPage = (): React.ReactElement => {
-  const getAllAuthors = (books: Book[]): Author[] => {
-    const allAuthors: Author[] = [];
-    books.forEach((book) => {
-      book.authors.forEach((author) => allAuthors.push(author));
-    });
-    const uniqueAuthorsMap = new Map(
-      allAuthors.map((item) => [item.fullName, item]),
-    );
-    const uniqueAuthors = Array.from(uniqueAuthorsMap, ([, value]) => value);
-    return uniqueAuthors;
-  };
-
-  return (
-    <Box
-      display="flex"
-      flexDirection="row"
-      alignItems="flex-start"
-      justifyContent="flex-start"
-      mt="10px"
-      mb="50px"
-    >
-      {mockReviews.map(
-        (review, key) =>
-          review.publishedAt &&
-          review.books[0].title && (
-            <ReviewThumbnail
-              key={key}
-              title={
-                review.books.length > 0 && review.books[0].seriesName
-                  ? review.books[0].seriesName
-                  : review.books[0].title
-              }
-              coverImage={review.books[0].coverImage}
-              authors={getAllAuthors(review.books)}
-              publishDate={new Date(review.publishedAt)}
-            />
-          ),
-      )}
-    </Box>
-  );
+  return <ReviewsGrid />;
 };
 
 export default MockSearchPage;

--- a/frontend/src/components/pages/MockSearch/ReviewThumbnail.tsx
+++ b/frontend/src/components/pages/MockSearch/ReviewThumbnail.tsx
@@ -1,36 +1,53 @@
-import { Flex, Image, Text } from "@chakra-ui/react";
+import { Box, Image, Text } from "@chakra-ui/react";
 import React from "react";
 
 import { Author } from "../../../types/BookTypes";
+import CircleBadge from "../../common/CircleBadge";
 
 interface ReviewThumbnailProps {
   title: string;
   coverImage: string;
   authors: Author[];
   publishDate: Date;
+  additionalBooks?: number;
 }
 
 const ReviewThumbnail = (props: ReviewThumbnailProps): React.ReactElement => {
-  const { title, coverImage, authors, publishDate } = props;
+  const { title, coverImage, authors, publishDate, additionalBooks } = props;
 
   return (
-    <Flex flexDir="column" maxW="220px" maxH="428px">
-      <Image
-        h="282px"
-        w="220px"
-        src={coverImage}
-        style={{ objectFit: "cover" }}
-      />
-      <Text textStyle="bookTitle" noOfLines={2} mt="12px">
+    <Box
+      flexDir="column"
+      w={["140px", "140px", "220px"]}
+      h={["300px", "300px", "410px"]}
+    >
+      <Box position="relative">
+        <Image
+          h={["180px", "180px", "282px"]}
+          w={["140px", "140px", "220px"]}
+          src={coverImage}
+          style={{ objectFit: "cover" }}
+        />
+        {additionalBooks && <CircleBadge count={additionalBooks} />}
+      </Box>
+      <Text
+        textStyle={["mobileBookTitle", "mobileBookTitle", "bookTitle"]}
+        noOfLines={2}
+        mt="4%"
+      >
         {title}
       </Text>
-      <Text textStyle="body" noOfLines={2} mt="4px">
+      <Text
+        textStyle={["mobileBody", "mobileBody", "body"]}
+        noOfLines={2}
+        mt="3%"
+      >
         {authors.map((elem) => elem.displayName).join(", ")}
       </Text>
-      <Text textStyle="caption" mt="10px">
+      <Text textStyle={["mobileCaption", "mobileCaption", "caption"]} mt="2%">
         {publishDate.toLocaleDateString("sv")}
       </Text>
-    </Flex>
+    </Box>
   );
 };
 

--- a/frontend/src/components/pages/MockSearch/ReviewsGrid.tsx
+++ b/frontend/src/components/pages/MockSearch/ReviewsGrid.tsx
@@ -22,8 +22,9 @@ const ReviewsGrid = (): React.ReactElement => {
     <Center mt="50px">
       <SimpleGrid
         minChildWidth={["140px", "140px", "240px"]}
-        w={["85%", "80%", "70%"]}
+        w={["85%", "80%", "80%"]}
         spacingY={[0, 4, 10]}
+        spacingX={[2, 5, 5]}
       >
         {mockReviews.map(
           (review, key) =>

--- a/frontend/src/components/pages/MockSearch/ReviewsGrid.tsx
+++ b/frontend/src/components/pages/MockSearch/ReviewsGrid.tsx
@@ -1,0 +1,57 @@
+import { Center, SimpleGrid } from "@chakra-ui/react";
+import React from "react";
+
+import { Author, Book } from "../../../types/BookTypes";
+import mockReviews from "./mockReviews";
+import ReviewThumbnail from "./ReviewThumbnail";
+
+const ReviewsGrid = (): React.ReactElement => {
+  const getAllAuthors = (books: Book[]): Author[] => {
+    const allAuthors: Author[] = [];
+    books.forEach((book) => {
+      book.authors.forEach((author) => allAuthors.push(author));
+    });
+    const uniqueAuthorsMap = new Map(
+      allAuthors.map((item) => [item.fullName, item]),
+    );
+    const uniqueAuthors = Array.from(uniqueAuthorsMap, ([, value]) => value);
+    return uniqueAuthors;
+  };
+
+  return (
+    <Center mt="50px">
+      <SimpleGrid
+        minChildWidth={["140px", "140px", "240px"]}
+        w={["85%", "80%", "70%"]}
+        spacingY={[0, 4, 10]}
+      >
+        {mockReviews.map(
+          (review, key) =>
+            review.publishedAt &&
+            review.books[0].title && (
+              <Center>
+                <ReviewThumbnail
+                  key={key}
+                  title={
+                    review.books.length > 0 && review.books[0].seriesName
+                      ? review.books[0].seriesName
+                      : review.books[0].title
+                  }
+                  coverImage={review.books[0].coverImage}
+                  authors={getAllAuthors(review.books)}
+                  publishDate={new Date(review.publishedAt)}
+                  additionalBooks={
+                    review.books.length > 1
+                      ? review.books.length - 1
+                      : undefined
+                  }
+                />
+              </Center>
+            ),
+        )}
+      </SimpleGrid>
+    </Center>
+  );
+};
+
+export default ReviewsGrid;

--- a/frontend/src/components/pages/MockSearch/mockReviews.ts
+++ b/frontend/src/components/pages/MockSearch/mockReviews.ts
@@ -139,7 +139,7 @@ const mockMultipleBookReview: Review = {
     firstName: "jessie",
     lastName: "peng",
   },
-  books: [hp1, hp2],
+  books: [hp1, hp2, hp1, hp2],
   updatedAt: 12,
   publishedAt: 20171111212,
   createdAt: 14,

--- a/frontend/src/components/pages/MockSearch/mockReviews.ts
+++ b/frontend/src/components/pages/MockSearch/mockReviews.ts
@@ -145,10 +145,30 @@ const mockMultipleBookReview: Review = {
   createdAt: 14,
 };
 
+const mockMultipleBookReviews2: Review = {
+  reviewId: 12,
+  body: "body of review",
+  byline: "byline",
+  featured: true,
+  createdByUser: {
+    firstName: "jessie",
+    lastName: "peng",
+  },
+  books: [mockGenericBookData, mockLongTitleBookData],
+  updatedAt: 12,
+  publishedAt: 20171111333,
+  createdAt: 14,
+};
+
 const mockReviews: Review[] = [
   mockSingleBookReview,
   mockMultipleBookReview,
   mockSingleBookLongTitleReview,
+  mockSingleBookReview,
+  mockMultipleBookReview,
+  mockSingleBookLongTitleReview,
+  mockSingleBookReview,
+  mockMultipleBookReviews2,
 ];
 
 export default mockReviews;

--- a/frontend/src/theme/index.tsx
+++ b/frontend/src/theme/index.tsx
@@ -16,6 +16,10 @@ const customTheme = extendTheme({
       fontFamily: "DM Sans",
       fontSize: "16px",
     },
+    mobileBody: {
+      fontFamily: "DM Sans",
+      fontSize: "13px",
+    },
     h4: {
       fontFamily: "DM Sans",
       color: "#fff",
@@ -30,10 +34,22 @@ const customTheme = extendTheme({
       fontWeight: "medium",
       lineHeight: "26px",
     },
+    mobileBookTitle: {
+      fontFamily: "DM Sans",
+      color: "#000000",
+      fontSize: "18px",
+      fontWeight: "medium",
+      lineHeight: "20px",
+    },
     caption: {
       fontFamily: "DM Sans",
       color: "gray.500",
       fontSize: "13px",
+    },
+    mobileCaption: {
+      fontFamily: "DM Sans",
+      color: "gray.500",
+      fontSize: "10px",
     },
   },
   colors: {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Grid of Reviews Component](https://www.notion.so/uwblueprintexecs/16fb020b93f641c8b384f76a1b3c769e?v=aedc8d99cd8b437cb556ece10f3c0e3c&p=fd4d68a50c9947da8a1e3a21582fad5f)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Made responsive grid for desktop/mobile view
* Also added a badge displaying number of additional books in a review from this last ticket (https://www.notion.so/uwblueprintexecs/16fb020b93f641c8b384f76a1b3c769e?v=aedc8d99cd8b437cb556ece10f3c0e3c&p=73b75f1d3b8f4901a8e565445fcc554b) I forgot to implement


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to http://localhost:3000/test/mock-search-page
2. Change different viewports and verify that grid is responsive (go to inspect console and choose different mobile views)
3. Also verify that badge displaying +number is displaying the correct number of books.

Video demo:
https://drive.google.com/file/d/1GwNKlrHHKeT0X5soN6Y3W_w-MDNiCC-T/view?usp=sharing


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
