### PR TITLE
[Bug] Delete from review page

### DIFF
--- a/frontend/src/components/pages/CreateReview/CreateReview.tsx
+++ b/frontend/src/components/pages/CreateReview/CreateReview.tsx
@@ -168,6 +168,29 @@ const CreateReview = ({ id }: CreateReviewProps): React.ReactElement => {
   };
 
   /**
+   * Deletes a review with the given index
+   */
+  const deleteReview = async () => {
+    if (id) {
+      try {
+        setLoading(true);
+        await reviewAPIClient.deleteReviewById(id);
+        newToast("success", "Review deleted", "Your review has been deleted");
+        history.replace("/dashboard");
+      } catch (e) {
+        newToast(
+          "error",
+          "Error deleting review",
+          "Something went wrong, please refresh the page and try again.",
+        );
+      }
+      setLoading(false);
+    } else {
+      history.push("/dashboard");
+    }
+  };
+
+  /**
    * Function to be called when the review is published/saved as a draft.
    */
   const onSubmit = async (publish = false) => {
@@ -312,7 +335,7 @@ const CreateReview = ({ id }: CreateReviewProps): React.ReactElement => {
       <DeleteReviewModal
         isOpen={showDeleteReviewModal}
         onClose={onDeleteReviewModalClose}
-        deleteReview={() => {}}
+        deleteReview={() => deleteReview()}
       />
       {/*  on leaving the page we need to have the save as draft window confirmation pop up, disabled for now 
       {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Delete doesn't work from review page](https://www.notion.so/uwblueprintexecs/16fb020b93f641c8b384f76a1b3c769e?v=aedc8d99cd8b437cb556ece10f3c0e3c&p=e33929e2f17242ba8e33ff3f609b3a6e)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added delete review function that deletes review by id if user is editing a review and navigates back to dashboard
* otherwise, if user is creating a new review and deletes it, user is just redirect to dashboard


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Edit an existing review and click the trash icon beside publish to delete it. Verify that it deletes.
2. Create a new review but do not publish. Click the trash icon to delete it and verifies it navigates back to dashboard.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
