### PR TITLE
Add sequelize-mandated timestamps to book_genre and book_tag tables

### DIFF
--- a/backend/typescript/migrations/20220713231135-add-createdAt-updatedAt-to-book-genre-and-book-tag.js
+++ b/backend/typescript/migrations/20220713231135-add-createdAt-updatedAt-to-book-genre-and-book-tag.js
@@ -1,0 +1,72 @@
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const bookGenreDef = await queryInterface.describeTable("book_genre");
+    const bookTagDef = await queryInterface.describeTable("book_tag");
+
+    return queryInterface.sequelize.transaction(async (t) => {
+      if (!bookGenreDef.createdAt)
+        await queryInterface.addColumn(
+          "book_genre",
+          "createdAt",
+          { type: Sequelize.DATE },
+          { transaction: t },
+        );
+      if (!bookGenreDef.updatedAt)
+        await queryInterface.addColumn(
+          "book_genre",
+          "updatedAt",
+          { type: Sequelize.DATE },
+          { transaction: t },
+        );
+
+      if (!bookTagDef.createdAt)
+        await queryInterface.addColumn(
+          "book_tag",
+          "createdAt",
+          { type: Sequelize.DATE },
+          { transaction: t },
+        );
+      if (!bookTagDef.updatedAt)
+        await queryInterface.addColumn(
+          "book_tag",
+          "updatedAt",
+          { type: Sequelize.DATE },
+          { transaction: t },
+        );
+
+      return Promise.resolve();
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn(
+        "book_genre",
+        "createdAt",
+        { type: Sequelize.DATE },
+        { transaction: t },
+      );
+      await queryInterface.removeColumn(
+        "book_genre",
+        "updatedAt",
+        { type: Sequelize.DATE },
+        { transaction: t },
+      );
+
+      await queryInterface.removeColumn(
+        "book_tag",
+        "createdAt",
+        { type: Sequelize.DATE },
+        { transaction: t },
+      );
+      await queryInterface.removeColumn(
+        "book_tag",
+        "updatedAt",
+        { type: Sequelize.DATE },
+        { transaction: t },
+      );
+
+      return Promise.resolve();
+    });
+  },
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Sequelize models expect tables they reference to have createdAt and updatedAt Date fields (fetched implicitly) Added a migration that adds these fields to `book_genre` and `book_tag` should they not exist



<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run the up migration
2. Verify `createdAt`, `updatedAt` columns exist
3. Login to the platform and try a bunch of things
    a. Add reviews,
    b. Delete reviews,
    c. Edit reviews, try modifying a bunch of fields
4. Run the down migration
5. Verify those two columns got removed



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
