### PR TITLE
[Tech] Refactor deleteReview

### DIFF
--- a/backend/typescript/services/implementations/reviewService.ts
+++ b/backend/typescript/services/implementations/reviewService.ts
@@ -244,6 +244,10 @@ class ReviewService implements IReviewService {
           transaction: txn,
         });
 
+        // TODO: can end up deleting the same author/publisher/series twice if
+        // there are books in the same review with the same author/publisher/series.
+        // fix this by grouping them into sets and iterating over those instead of the books
+
         // Delete authors (if necessary)
         book.authors.forEach(async (author: PgAuthor) => {
           const authorsOtherBooks = await PgBookAuthor.findAll({

--- a/backend/typescript/services/implementations/reviewService.ts
+++ b/backend/typescript/services/implementations/reviewService.ts
@@ -247,7 +247,10 @@ class ReviewService implements IReviewService {
         // Delete authors (if necessary)
         book.authors.forEach(async (author: PgAuthor) => {
           const authorsOtherBooks = await PgBookAuthor.findAll({
-            where: { author_id: author.id, book_id: { [Op.notIn]: allBookIds } },
+            where: {
+              author_id: author.id,
+              book_id: { [Op.notIn]: allBookIds },
+            },
           });
           if (authorsOtherBooks.length === 0) {
             // Delete author
@@ -278,7 +281,10 @@ class ReviewService implements IReviewService {
         // Delete series (if necessary)
         if (book.series) {
           const seriesOtherBooks = await PgBook.findAll({
-            where: { series_id: book.series.id, id: { [Op.notIn]: allBookIds } },
+            where: {
+              series_id: book.series.id,
+              id: { [Op.notIn]: allBookIds },
+            },
           });
           if (seriesOtherBooks.length === 0) {
             // Delete series

--- a/backend/typescript/services/implementations/reviewService.ts
+++ b/backend/typescript/services/implementations/reviewService.ts
@@ -234,6 +234,8 @@ class ReviewService implements IReviewService {
       throw new Error(`Review id ${id} not found`);
     }
 
+    const allBookIds = reviewToDelete.books.map((book: PgBook) => book.id);
+
     await Promise.all(
       reviewToDelete.books.map(async (book: PgBook) => {
         // Delete book
@@ -245,7 +247,7 @@ class ReviewService implements IReviewService {
         // Delete authors (if necessary)
         book.authors.forEach(async (author: PgAuthor) => {
           const authorsOtherBooks = await PgBookAuthor.findAll({
-            where: { author_id: author.id, book_id: { [Op.not]: book.id } },
+            where: { author_id: author.id, book_id: { [Op.notIn]: allBookIds } },
           });
           if (authorsOtherBooks.length === 0) {
             // Delete author
@@ -261,7 +263,7 @@ class ReviewService implements IReviewService {
           const publishersOtherBooks = await PgBookPublisher.findAll({
             where: {
               publisher_id: publisher.id,
-              book_id: { [Op.not]: book.id },
+              book_id: { [Op.notIn]: allBookIds },
             },
           });
           if (publishersOtherBooks.length === 0) {
@@ -276,7 +278,7 @@ class ReviewService implements IReviewService {
         // Delete series (if necessary)
         if (book.series) {
           const seriesOtherBooks = await PgBook.findAll({
-            where: { series_id: book.series.id, id: { [Op.not]: book.id } },
+            where: { series_id: book.series.id, id: { [Op.notIn]: allBookIds } },
           });
           if (seriesOtherBooks.length === 0) {
             // Delete series

--- a/backend/typescript/services/implementations/reviewService.ts
+++ b/backend/typescript/services/implementations/reviewService.ts
@@ -224,7 +224,7 @@ class ReviewService implements IReviewService {
     }
   }
 
-  async deleteReviewHelper(id: string, txn: Transaction): Promise<Boolean> {
+  async deleteReviewHelper(id: string, txn: Transaction): Promise<boolean> {
     const reviewToDelete = await PgReview.findByPk(id, {
       transaction: txn,
       include: [{ all: true, nested: true }],


### PR DESCRIPTION
Old deleteReview broke when deleting last book in series. It would not delete it from the Series table because of async shenanigans leading to the transaction being committed before it could delete.

## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have run docker-compose up and my project compiled
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
