### PR TITLE
[Tech] Change book_tag, book_genre constraints to cascade

### DIFF
--- a/backend/typescript/migrations/20220715012943-change-book-tag-book-genre-constraints-to-cascade.js
+++ b/backend/typescript/migrations/20220715012943-change-book-tag-book-genre-constraints-to-cascade.js
@@ -1,0 +1,147 @@
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async (t) => {
+      // Remove previous constraints
+      await queryInterface.removeConstraint(
+        "book_tag",
+        "book_tag_book_id_fkey",
+        { transaction: t },
+      );
+      await queryInterface.removeConstraint(
+        "book_tag",
+        "book_tag_tag_name_fkey",
+        { transaction: t },
+      );
+      await queryInterface.removeConstraint(
+        "book_genre",
+        "book_genre_book_id_fkey",
+        { transaction: t },
+      );
+      await queryInterface.removeConstraint(
+        "book_genre",
+        "book_genre_genre_name_fkey",
+        { transaction: t },
+      );
+
+      // Add new constraints with cascade
+      await queryInterface.addConstraint("book_tag", {
+        fields: ["book_id"],
+        type: "foreign key",
+        name: "book_tag_book_id_fkey",
+        references: {
+          table: "books",
+          field: "id",
+        },
+        onDelete: "CASCADE",
+        onUpdate: "CASCADE",
+        transaction: t,
+      });
+      await queryInterface.addConstraint("book_tag", {
+        fields: ["tag_name"],
+        type: "foreign key",
+        name: "book_tag_tag_name_fkey",
+        references: {
+          table: "tags",
+          field: "name",
+        },
+        onDelete: "CASCADE",
+        onUpdate: "CASCADE",
+        transaction: t,
+      });
+
+      await queryInterface.addConstraint("book_genre", {
+        fields: ["book_id"],
+        type: "foreign key",
+        name: "book_genre_book_id_fkey",
+        references: {
+          table: "books",
+          field: "id",
+        },
+        onDelete: "CASCADE",
+        onUpdate: "CASCADE",
+        transaction: t,
+      });
+      await queryInterface.addConstraint("book_genre", {
+        fields: ["genre_name"],
+        type: "foreign key",
+        name: "book_genre_genre_name_fkey",
+        references: {
+          table: "genres",
+          field: "name",
+        },
+        onDelete: "CASCADE",
+        onUpdate: "CASCADE",
+        transaction: t,
+      });
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async (t) => {
+      // Remove previous constraints
+      await queryInterface.removeConstraint(
+        "book_tag",
+        "book_tag_book_id_fkey",
+        { transaction: t },
+      );
+      await queryInterface.removeConstraint(
+        "book_tag",
+        "book_tag_tag_name_fkey",
+        { transaction: t },
+      );
+      await queryInterface.removeConstraint(
+        "book_genre",
+        "book_genre_book_id_fkey",
+        { transaction: t },
+      );
+      await queryInterface.removeConstraint(
+        "book_genre",
+        "book_genre_genre_name_fkey",
+        { transaction: t },
+      );
+
+      // Add back old constraints without cascade
+      await queryInterface.addConstraint("book_tag", {
+        fields: ["book_id"],
+        type: "foreign key",
+        name: "book_tag_book_id_fkey",
+        references: {
+          table: "books",
+          field: "id",
+        },
+        transaction: t,
+      });
+      await queryInterface.addConstraint("book_tag", {
+        fields: ["tag_name"],
+        type: "foreign key",
+        name: "book_tag_tag_name_fkey",
+        references: {
+          table: "tags",
+          field: "name",
+        },
+        transaction: t,
+      });
+
+      await queryInterface.addConstraint("book_genre", {
+        fields: ["book_id"],
+        type: "foreign key",
+        name: "book_genre_book_id_fkey",
+        references: {
+          table: "books",
+          field: "id",
+        },
+        transaction: t,
+      });
+      await queryInterface.addConstraint("book_genre", {
+        fields: ["genre_name"],
+        type: "foreign key",
+        name: "book_genre_genre_name_fkey",
+        references: {
+          table: "genres",
+          field: "name",
+        },
+        transaction: t,
+      });
+    });
+  },
+};

--- a/frontend/src/APIClients/ReviewAPIClient.ts
+++ b/frontend/src/APIClients/ReviewAPIClient.ts
@@ -75,14 +75,10 @@ const handleReview = async (
   Delete review by id
 */
 const deleteReviewById = async (id: string): Promise<ReviewResponse> => {
-  try {
-    const { data } = await baseAPIClient.delete(`/reviews/${id.toString()}`, {
-      headers: { Authorization: getBearerToken() },
-    });
-    return data;
-  } catch (error) {
-    return error as ReviewResponse;
-  }
+  const { data } = await baseAPIClient.delete(`/reviews/${id.toString()}`, {
+    headers: { Authorization: getBearerToken() },
+  });
+  return data;
 };
 
 /**

--- a/frontend/src/components/pages/AdminDashboard/AdminDashboard.tsx
+++ b/frontend/src/components/pages/AdminDashboard/AdminDashboard.tsx
@@ -70,6 +70,10 @@ const AdminDashboard = (): React.ReactElement => {
     try {
       setIsLoading(true);
       await reviewAPIClient.deleteReviewById(deleteReviewId.toString());
+      const newData = [...data];
+      const deleteReviewIndex = getIndex(deleteReviewId);
+      newData.splice(deleteReviewIndex, 1);
+      setData(newData);
       newToast("success", "Review deleted", "Your review has been deleted");
     } catch (e) {
       newToast(
@@ -78,10 +82,6 @@ const AdminDashboard = (): React.ReactElement => {
         "Something went wrong, please refresh the page and try again.",
       );
     }
-    const newData = [...data];
-    const deleteReviewIndex = getIndex(deleteReviewId);
-    newData.splice(deleteReviewIndex, 1);
-    setData(newData);
     setIsLoading(false);
   };
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Change-book_tag-book_genre-constraints-to-cascade-d7faff9b64b848bea8ecd739b3f80b86)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
This PR solves 2 issues:
#### 1. The frontend currently suppresses errors on delete, propagated these errors.
#### 2. Our fk constraints on the `book_genre` and `book_tag` tables don't cascade delete/update
* This causes deleting to fail (ie fk constraint violation)
* Migrated the constraints to support cascade on delete/update



<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Add 2 reviews containing books with Tags or Genres (maybe checkout #136 to do this using Postman)
2. Checkout this branch
3. Try deleting a review, it fails
4. Run migrations up
5. Deleting that added review should work
6. Run migrations down
7. Try deleting a review, it should fail again


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Make sure everything's spelt properly in the migration lol


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
