### PR TITLE
[Bug] fixed preview overflow in admindashboard

### DIFF
--- a/frontend/src/components/PreviewReview/PreviewReviewModal.tsx
+++ b/frontend/src/components/PreviewReview/PreviewReviewModal.tsx
@@ -56,7 +56,7 @@ const PreviewReviewModal = ({
     <>
       <Modal isOpen={isOpen} onClose={onClose} size="2xl" isCentered>
         <ModalOverlay />
-        <ModalContent fontFamily="DM Sans">
+        <ModalContent overflowY="auto" maxHeight="100vh" fontFamily="DM Sans">
           <ModalHeader backgroundColor="#FFF8F3" borderRadius={10}>
             <HStack spacing={150} fontSize={14}>
               <HStack>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,13 +1,17 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
+}
+
+.css-1yb2anq {
+  overflow-y: hidden !important;
 }


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Preview Review Modal overflows screen when review is too long](https://www.notion.so/uwblueprintexecs/Preview-Review-Modal-overflows-screen-when-review-is-too-long-f44d77645247499dba83e1f1085c8a39)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add an overflow css to allow for a scroll bar if the review is too big


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a really long review
2.  Preview it in admin dashboard
3. Should now be scrollable and should only scroll the modal


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* The review renders properly, and only the modal scrolls not the page


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have run docker-compose up and my project compiled
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
