### PR TITLE
[Fix] Make tags, genres optional fields in ReviewRequest

### DIFF
--- a/backend/typescript/services/implementations/reviewService.ts
+++ b/backend/typescript/services/implementations/reviewService.ts
@@ -181,7 +181,7 @@ class ReviewService implements IReviewService {
     book.authors.forEach((author) => {
       authorsRes.push(this.findOrCreateAuthor(newBook, author, t));
     });
-    const tagsRet = await this.findOrCreateTags(newBook, book.tags, t);
+    const tagsRet = await this.findOrCreateTags(newBook, book.tags || [], t);
 
     const authors = await Promise.all(authorsRes);
     const authorsRet: AuthorResponse[] = authors.map((author) => ({
@@ -205,7 +205,7 @@ class ReviewService implements IReviewService {
 
     const genresRet: Genre[] = await this.findOrCreateGenres(
       newBook,
-      book.genres,
+      book.genres || [],
       t,
     );
 

--- a/backend/typescript/services/interfaces/IReviewService.ts
+++ b/backend/typescript/services/interfaces/IReviewService.ts
@@ -51,10 +51,10 @@ export interface BookRequest {
   minAge: number;
   maxAge: number;
   authors: AuthorRequest[];
-  genres: Genre[];
+  genres?: Genre[] | null;
   publishers: PublisherRequest[];
   series: Series;
-  tags: Tag[];
+  tags?: Tag[] | null;
 }
 
 export interface Tag {

--- a/backend/typescript/services/interfaces/checkers/IReviewService-ti.ts
+++ b/backend/typescript/services/interfaces/checkers/IReviewService-ti.ts
@@ -31,10 +31,6 @@ export const PublisherResponse = t.iface([], {
 });
 
 export const Genre = t.iface([], {
-  name: "String",
-});
-
-export const Tag = t.iface([], {
   name: "string",
 });
 
@@ -60,11 +56,15 @@ export const BookRequest = t.iface([], {
   formats: t.union(t.array("Format"), "null"),
   minAge: "number",
   maxAge: "number",
-  genres: t.array("Genre"),
-  tags: t.array("Tag"),
   authors: t.array("AuthorRequest"),
+  genres: t.opt(t.union(t.array("Genre"), "null")),
   publishers: t.array("PublisherRequest"),
   series: "Series",
+  tags: t.opt(t.union(t.array("Tag"), "null")),
+});
+
+export const Tag = t.iface([], {
+  name: "string",
 });
 
 export const BookResponse = t.iface([], {
@@ -78,11 +78,11 @@ export const BookResponse = t.iface([], {
   formats: t.union(t.array("Format"), "null"),
   minAge: "number",
   maxAge: "number",
-  genres: t.array("Genre"),
-  tags: t.array("Tag"),
   authors: t.array("AuthorResponse"),
+  genres: t.array("Genre"),
   publishers: t.array("PublisherResponse"),
   series: "Series",
+  tags: t.array("Tag"),
 });
 
 export const User = t.iface([], {
@@ -133,12 +133,12 @@ const exportedTypeSuite: t.ITypeSuite = {
   AuthorResponse,
   PublisherRequest,
   PublisherResponse,
+  Genre,
   Format,
   Series,
   BookRequest,
-  BookResponse,
-  Genre,
   Tag,
+  BookResponse,
   User,
   ReviewRequestDTO,
   ReviewResponseDTO,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
#### Tags and Genres were previously required fields, causing development branch to break since frontend changes haven't been merged
* Defaulted tags/genres to [] if not supplied and made fields optional


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Publish a review (on this branch)
2. Edit a review


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
