### PR TITLE
[Feat] Made givecloud private by an env variable

### DIFF
--- a/backend/typescript/middlewares/givecloud.ts
+++ b/backend/typescript/middlewares/givecloud.ts
@@ -17,4 +17,4 @@ const isGiveCloudEnabled = () => {
   };
 };
 
-export default isGiveCloudEnabled
+export default isGiveCloudEnabled;

--- a/backend/typescript/middlewares/givecloud.ts
+++ b/backend/typescript/middlewares/givecloud.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 
 /* 
-checks the .env file to see if the givecloud webhook is enabled, 
+checks the environment variables to see if the givecloud webhook is enabled, 
 works if GIVECLOUD_WEBHOOK_ENABLE has a value of 1, the route is disabled if the value is anything else or not present
 */
 const isGiveCloudEnabled = () => {

--- a/backend/typescript/middlewares/validators/givecloudValidators.ts
+++ b/backend/typescript/middlewares/validators/givecloudValidators.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from "express";
+
+/* 
+checks the .env file to see if the givecloud webhook is enabled, 
+works if GIVECLOUD_WEBHOOK_ENABLE has a value of 1, the route is disabled if the value is anything else or not present
+*/
+export const isGiveCloudEnabled = () => {
+    return async(req: Request, res: Response, next: NextFunction): Promise<Response | void> =>{
+      if (process.env.GIVECLOUD_WEBHOOK_ENABLE !== "1") {
+        return res.status(404).json({ error: "Path does not exist" });
+      }
+      return next();
+    }
+  };

--- a/backend/typescript/middlewares/validators/givecloudValidators.ts
+++ b/backend/typescript/middlewares/validators/givecloudValidators.ts
@@ -4,11 +4,17 @@ import { Request, Response, NextFunction } from "express";
 checks the .env file to see if the givecloud webhook is enabled, 
 works if GIVECLOUD_WEBHOOK_ENABLE has a value of 1, the route is disabled if the value is anything else or not present
 */
-export const isGiveCloudEnabled = () => {
-    return async(req: Request, res: Response, next: NextFunction): Promise<Response | void> =>{
-      if (process.env.GIVECLOUD_WEBHOOK_ENABLE !== "1") {
-        return res.status(404).json({ error: "Path does not exist" });
-      }
-      return next();
+const isGiveCloudEnabled = () => {
+  return async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<Response | void> => {
+    if (process.env.GIVECLOUD_WEBHOOK_ENABLE !== "1") {
+      return res.status(404).json({ error: "Path does not exist" });
     }
+    return next();
   };
+};
+
+export default isGiveCloudEnabled

--- a/backend/typescript/rest/givecloud.ts
+++ b/backend/typescript/rest/givecloud.ts
@@ -9,7 +9,7 @@ import IEmailService from "../services/interfaces/emailService";
 import IAuthService from "../services/interfaces/authService";
 import nodemailerConfig from "../nodemailer.config";
 import authDtoToToUserDto from "../utilities/authUtils";
-import  isGiveCloudEnabled  from "../middlewares/validators/givecloudValidators";
+import isGiveCloudEnabled from "../middlewares/givecloud";
 
 const givecloudRouter: Router = Router();
 

--- a/backend/typescript/rest/givecloud.ts
+++ b/backend/typescript/rest/givecloud.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+import { Router, Request,Response,NextFunction } from "express";
 import { body, validationResult } from "express-validator";
 import AuthService from "../services/implementations/authService";
 import UserService from "../services/implementations/userService";
@@ -16,6 +16,15 @@ const userService = new UserService();
 const emailService: IEmailService = new EmailService(nodemailerConfig);
 const authService: IAuthService = new AuthService(userService, emailService);
 
+
+const isAuthroized = (req:Request,res:Response, next: NextFunction) => {
+  if(process.env['GIVECLOUD_TOKEN'] !== req.get('GIVECLOUD_TOKEN')){
+    return res.status(403).json({ error: 'No correct credentials sent!' });
+  }
+  next()
+};
+
+
 givecloudRouter.post(
   "/user.subscription_paid",
   body(
@@ -29,7 +38,8 @@ givecloudRouter.post(
   body("supporter.email", "supporter email is required").exists(),
   body("supporter.first_name", "supporter first_name is required").exists(),
   body("supporter.last_name", "supporter last_name is required").exists(),
-  async (req, res) => {
+  (req:Request,res:Response,next:NextFunction) => isAuthroized(req,res,next),
+  async (req:Request, res:Response) => {
     try {
       const errors = validationResult(req);
       if (errors.isEmpty()) {

--- a/backend/typescript/rest/givecloud.ts
+++ b/backend/typescript/rest/givecloud.ts
@@ -1,4 +1,4 @@
-import { Router, Request,Response,NextFunction } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { body, validationResult } from "express-validator";
 import AuthService from "../services/implementations/authService";
 import UserService from "../services/implementations/userService";
@@ -16,14 +16,12 @@ const userService = new UserService();
 const emailService: IEmailService = new EmailService(nodemailerConfig);
 const authService: IAuthService = new AuthService(userService, emailService);
 
-
-const isAuthroized = (req:Request,res:Response, next: NextFunction) => {
-  if(process.env['GIVECLOUD_TOKEN'] !== req.get('GIVECLOUD_TOKEN')){
-    return res.status(403).json({ error: 'No correct credentials sent!' });
+const isAuthroized = (req: Request, res: Response, next: NextFunction) => {
+  if (process.env.GIVECLOUD_TOKEN !== req.get("GIVECLOUD_TOKEN")) {
+    return res.status(403).json({ error: "No correct credentials sent!" });
   }
-  next()
+  return next();
 };
-
 
 givecloudRouter.post(
   "/user.subscription_paid",
@@ -38,8 +36,9 @@ givecloudRouter.post(
   body("supporter.email", "supporter email is required").exists(),
   body("supporter.first_name", "supporter first_name is required").exists(),
   body("supporter.last_name", "supporter last_name is required").exists(),
-  (req:Request,res:Response,next:NextFunction) => isAuthroized(req,res,next),
-  async (req:Request, res:Response) => {
+  (req: Request, res: Response, next: NextFunction) =>
+    isAuthroized(req, res, next),
+  async (req: Request, res: Response) => {
     try {
       const errors = validationResult(req);
       if (errors.isEmpty()) {

--- a/backend/typescript/rest/givecloud.ts
+++ b/backend/typescript/rest/givecloud.ts
@@ -9,7 +9,7 @@ import IEmailService from "../services/interfaces/emailService";
 import IAuthService from "../services/interfaces/authService";
 import nodemailerConfig from "../nodemailer.config";
 import authDtoToToUserDto from "../utilities/authUtils";
-import { isGiveCloudEnabled } from "../middlewares/validators/givecloudValidators";
+import  isGiveCloudEnabled  from "../middlewares/validators/givecloudValidators";
 
 const givecloudRouter: Router = Router();
 


### PR DESCRIPTION


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a variable to the env file (not pushed)
* Used that variable and double checked with the authorization sent from a post request to make sure they are the same other wise we return a 400 error, and do not proceed further


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
1. Send a request to the givecloud endpoint without an authorization (should return a 400 erro)
2. Send a request to the givecloud endpoint with the correct authorization key but wrong value (400 error)
3. Send a request to the givecloud endpoint with the correct key and value (goes through)



## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
