### PR TITLE
[Feat]: Add Tags/Genres to Book Previews

### DIFF
--- a/frontend/src/components/PreviewReview/PreviewReview.tsx
+++ b/frontend/src/components/PreviewReview/PreviewReview.tsx
@@ -5,8 +5,11 @@ import {
   Icon,
   Image,
   Stack,
+  Tag,
   Text,
   VStack,
+  Wrap,
+  WrapItem,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 
@@ -136,17 +139,38 @@ const PreviewReview = ({
                     </>
                   ))}
                   <Text>{`Ages ${review.books[currentBook].minAge}-${review.books[currentBook].maxAge}`}</Text>
+                  {review.books[currentBook].genres.length +
+                    review.books[currentBook].tags.length >
+                    0 && (
+                    <Wrap spacing={1} paddingTop={3}>
+                      {review.books[currentBook].genres.map((genre) => (
+                        <WrapItem key={`genre-${genre.name}`}>
+                          <Tag
+                            size="sm"
+                            variant="solid"
+                            bgColor="#90CDF4"
+                            color="black"
+                          >
+                            {genre.name}
+                          </Tag>
+                        </WrapItem>
+                      ))}
+                      {review.books[currentBook].tags.map((tag) => (
+                        <WrapItem key={`tag-${tag.name}`}>
+                          <Tag
+                            size="sm"
+                            variant="solid"
+                            bgColor="#F7E1A8"
+                            color="black"
+                          >
+                            {tag.name}
+                          </Tag>
+                        </WrapItem>
+                      ))}
+                    </Wrap>
+                  )}
                 </Stack>
               </Box>
-              <HStack spacing={2}>
-                {/* {review.tags.map((tag, index) => (
-                  <Box key={index}>
-                    <Tag bgColor="#F6E1A8" size="sm" fontWeight={600}>
-                      {tag.name}
-                    </Tag>
-                  </Box>
-                ))} */}
-              </HStack>
             </Stack>
           </Box>
           <ChevronRightIcon


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add Tags/Genres to Book Previews](https://www.notion.so/uwblueprintexecs/16fb020b93f641c8b384f76a1b3c769e?v=aedc8d99cd8b437cb556ece10f3c0e3c&p=57fe0869572345a3a80eca4eecb5b71c&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add Tags/Genres to Book Previews


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. add/edit/remove genres/tags and preview


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have run docker-compose up and my project compiled
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
