### PR TITLE
[Bug]: Age is not previewing correctly

### DIFF
--- a/backend/typescript/models/book.model.ts
+++ b/backend/typescript/models/book.model.ts
@@ -53,6 +53,7 @@ export default class Book extends Model {
   formats!: Format[];
 
   @Column({ type: DataType.RANGE(DataType.INTEGER) })
+  // note: sequelize stores 3-6 inclusive as [3-7)
   age_range!: Range[];
 
   @BelongsTo(() => Series)

--- a/backend/typescript/services/implementations/reviewService.ts
+++ b/backend/typescript/services/implementations/reviewService.ts
@@ -230,7 +230,7 @@ class ReviewService implements IReviewService {
       translator: newBook.translator || null,
       formats: newBook.formats,
       minAge: newBook.age_range[0].value,
-      maxAge: newBook.age_range[1].value,
+      maxAge: newBook.age_range[1].value - 1, // note: sequelize stores 3-6 inclusive as [3-7)
       authors: authorsRet,
       genres: genresRet,
       publishers: publishersRet,
@@ -449,7 +449,7 @@ class ReviewService implements IReviewService {
         translator: book.translator || null,
         formats: book.formats || null,
         minAge: book.age_range[0].value,
-        maxAge: book.age_range[1].value,
+        maxAge: book.age_range[1].value - 1, // note: sequelize stores 3-6 inclusive as [3-7)
         authors: authorsRet,
         genres: genresRet,
         publishers: publishersRet,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Age is not previewing correctly](https://www.notion.so/uwblueprintexecs/16fb020b93f641c8b384f76a1b3c769e?v=aedc8d99cd8b437cb556ece10f3c0e3c&p=25eb2d7845e74b12b19debbf386ddbc6&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* throw in a `-1` because sequelize stores 3-6 inclusive as [3-7)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Add book with age range, verify age range in preview


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
