### PR TITLE
[Feat]: Genre on Book Thumbnail

### DIFF
--- a/frontend/src/components/pages/SearchReviews/ReviewThumbnail.tsx
+++ b/frontend/src/components/pages/SearchReviews/ReviewThumbnail.tsx
@@ -74,7 +74,7 @@ const ReviewThumbnail = (props: ReviewThumbnailProps): React.ReactElement => {
         </Text>
         <Spacer />
         {genre && (
-          <Tag size="sm" variant="solid" bgColor="#F7E1A8" color="black">
+          <Tag size="sm" variant="solid" bgColor="#90CDF4" color="black">
             {genre}
           </Tag>
         )}

--- a/frontend/src/components/pages/SearchReviews/ReviewThumbnail.tsx
+++ b/frontend/src/components/pages/SearchReviews/ReviewThumbnail.tsx
@@ -1,4 +1,4 @@
-import { Box, Image, Text } from "@chakra-ui/react";
+import { Box, Flex, Image, Spacer, Tag, Text } from "@chakra-ui/react";
 import React from "react";
 import { useHistory } from "react-router-dom";
 
@@ -13,6 +13,7 @@ interface ReviewThumbnailProps {
   publishDate: Date;
   additionalBooks?: number;
   id: number;
+  genre?: string;
 }
 
 const ReviewThumbnail = (props: ReviewThumbnailProps): React.ReactElement => {
@@ -23,6 +24,7 @@ const ReviewThumbnail = (props: ReviewThumbnailProps): React.ReactElement => {
     authors,
     publishDate,
     additionalBooks,
+    genre,
   } = props;
 
   const history = useHistory();
@@ -66,9 +68,17 @@ const ReviewThumbnail = (props: ReviewThumbnailProps): React.ReactElement => {
       >
         {authors.map((elem) => elem.displayName).join(", ")}
       </Text>
-      <Text textStyle={["mobileCaption", "mobileCaption", "caption"]} mt="2%">
-        {publishDate.toLocaleDateString("sv")}
-      </Text>
+      <Flex>
+        <Text textStyle={["mobileCaption", "mobileCaption", "caption"]} mt="2%">
+          {publishDate.toLocaleDateString("sv")}
+        </Text>
+        <Spacer />
+        {genre && (
+          <Tag size="sm" variant="solid" bgColor="#F7E1A8" color="black">
+            {genre}
+          </Tag>
+        )}
+      </Flex>
     </Box>
   );
 };

--- a/frontend/src/components/pages/SearchReviews/ReviewsGrid.tsx
+++ b/frontend/src/components/pages/SearchReviews/ReviewsGrid.tsx
@@ -24,6 +24,29 @@ const ReviewsGrid = ({
     return uniqueAuthors;
   };
 
+  // picks one genre (if any) to show
+  const getGenre = (books: Book[]): string | undefined => {
+    if (books.length === 1) {
+      return books[0].genres.length !== 0 ? books[0].genres[0].name : undefined;
+    }
+
+    // return most frequent tag
+    const genreCount: Map<string, number> = new Map();
+    let maxName: string | undefined;
+    let maxCount = 0;
+    books.forEach((book) => {
+      book.genres.forEach(({ name }) => {
+        const newCount = (genreCount.get(name) || 0) + 1;
+        genreCount.set(name, newCount);
+        if (newCount > maxCount) {
+          maxName = name;
+          maxCount = newCount;
+        }
+      });
+    });
+    return maxName;
+  };
+
   // sort books based on series order
   displayedReviews.forEach((review) =>
     review.books.sort((a, b) => {
@@ -62,6 +85,7 @@ const ReviewsGrid = ({
                       ? review.books.length - 1
                       : undefined
                   }
+                  genre={getGenre(review.books)}
                 />
               </Center>
             ),


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Genre on Book Thumbnail](https://www.notion.so/uwblueprintexecs/16fb020b93f641c8b384f76a1b3c769e?v=aedc8d99cd8b437cb556ece10f3c0e3c&p=ca31ba03cb10475cb4165fb80f49577d&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* if one book take first genre
* if multiple books, find most frequent genre


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. create review with one/multiple genres
2. verify the correct genre shows in search

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
