### PR TITLE
[bug]: Previewing a Single Book

### DIFF
--- a/frontend/src/components/PreviewReview/PreviewReview.tsx
+++ b/frontend/src/components/PreviewReview/PreviewReview.tsx
@@ -34,6 +34,7 @@ const PreviewReview = ({
   isPageView = false,
 }: PreviewReviewProps): React.ReactElement => {
   const [currentBook, setCurrentBook] = useState<number>(0);
+  const multipleBooks = review.books.length > 1;
 
   // sort books based on series order
   review.books.sort((a, b) => {
@@ -63,14 +64,16 @@ const PreviewReview = ({
           mb="-12px"
           spacing={isPageView ? 20 : 0}
         >
-          <ChevronLeftIcon
-            boxSize="2em"
-            style={{
-              cursor: `${currentBook !== 0 ? "pointer" : "auto"}`,
-              color: `${currentBook !== 0 ? "black" : "lightgray"}`,
-            }}
-            onClick={handleLeftClick}
-          />
+          {multipleBooks && (
+            <ChevronLeftIcon
+              boxSize="2em"
+              style={{
+                cursor: `${currentBook !== 0 ? "pointer" : "auto"}`,
+                color: `${currentBook !== 0 ? "black" : "lightgray"}`,
+              }}
+              onClick={handleLeftClick}
+            />
+          )}
           <Box
             pr={16}
             pl={16}
@@ -173,36 +176,42 @@ const PreviewReview = ({
               </Box>
             </Stack>
           </Box>
-          <ChevronRightIcon
-            boxSize="2em"
-            style={{
-              cursor: `${
-                currentBook !== review.books.length - 1 ? "pointer" : "auto"
-              }`,
-              color: `${
-                currentBook !== review.books.length - 1 ? "black" : "lightgray"
-              }`,
-            }}
-            onClick={handleRightClick}
-          />
+          {multipleBooks && (
+            <ChevronRightIcon
+              boxSize="2em"
+              style={{
+                cursor: `${
+                  currentBook !== review.books.length - 1 ? "pointer" : "auto"
+                }`,
+                color: `${
+                  currentBook !== review.books.length - 1
+                    ? "black"
+                    : "lightgray"
+                }`,
+              }}
+              onClick={handleRightClick}
+            />
+          )}
         </HStack>
-        <HStack>
-          {Array.from(Array(review.books.length).keys()).map((_, index) => (
-            <Icon
-              key={index}
-              viewBox="0 0 200 200"
-              onClick={() => setCurrentBook(index)}
-              style={{ cursor: "pointer" }}
-            >
-              <path
-                fill={`${index === currentBook ? "black" : "none"}`}
-                stroke="black"
-                strokeWidth="12"
-                d="M 100, 100 m -75, 0 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0"
-              />
-            </Icon>
-          ))}
-        </HStack>
+        {multipleBooks && (
+          <HStack>
+            {Array.from(Array(review.books.length).keys()).map((_, index) => (
+              <Icon
+                key={index}
+                viewBox="0 0 200 200"
+                onClick={() => setCurrentBook(index)}
+                style={{ cursor: "pointer" }}
+              >
+                <path
+                  fill={`${index === currentBook ? "black" : "none"}`}
+                  stroke="black"
+                  strokeWidth="12"
+                  d="M 100, 100 m -75, 0 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0"
+                />
+              </Icon>
+            ))}
+          </HStack>
+        )}
         <VStack align="flex-start" width={isPageView ? "50%" : "80%"}>
           <Text fontWeight={400} fontSize="12px">
             <strong>Reviewed By: </strong>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Previewing a Single Book](https://www.notion.so/uwblueprintexecs/Previewing-a-Single-Book-f510c07114eb4de9b153971f1305bf9f)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* hide arrows and dots in only one book


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. check preview for one book, verify arrows and dots are not there
2. check preview for multiple book, verify arrows and dots are there

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
