### PR TITLE
[Bug] Fix Blank "Illustrated by" field in Book Preview

### DIFF
--- a/frontend/src/components/PreviewReview/PreviewReview.tsx
+++ b/frontend/src/components/PreviewReview/PreviewReview.tsx
@@ -116,14 +116,15 @@ const PreviewReview = ({
                         .join(", ")}
                     </Text>
                   </HStack>
-                  {review.books[currentBook].illustrator.length > 0 && (
-                    <HStack>
-                      <Text fontWeight={600}>Illustrated by:</Text>
-                      <Text fontWeight={400}>
-                        {review.books[currentBook].illustrator?.join(", ")}
-                      </Text>
-                    </HStack>
-                  )}
+                  {review.books[currentBook].illustrator.length > 0 &&
+                    review.books[currentBook].illustrator[0].length > 0 && (
+                      <HStack>
+                        <Text fontWeight={600}>Illustrated by:</Text>
+                        <Text fontWeight={400}>
+                          {review.books[currentBook].illustrator?.join(", ")}
+                        </Text>
+                      </HStack>
+                    )}
                 </Stack>
               </Box>
               <Box fontSize={12} paddingBottom={1}>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Book Preview Sometimes Shows Illustrator Even if Blank](https://www.notion.so/uwblueprintexecs/Book-Preview-Sometimes-Shows-Illustrator-Even-if-Blank-b23e87f5ffc9412dac72c8cff4a2b2dc)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added check to ensure illustrator by field does not show up if there are no illustrators


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a book and leave illustrator section like this:
<img width="358" alt="image" src="https://user-images.githubusercontent.com/59517368/185765574-5926adfc-ffa2-4893-b9f0-2ed76659b714.png">

2. Check that in book preview, there is no illustrated by section


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have run docker-compose up and my project compiled
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
