### PR TITLE
[Feat] Add price to review page

### DIFF
--- a/frontend/src/components/PreviewReview/PreviewReview.tsx
+++ b/frontend/src/components/PreviewReview/PreviewReview.tsx
@@ -136,7 +136,7 @@ const PreviewReview = ({
                   ))}
                   {review.books[currentBook].formats.map((format) => (
                     <>
-                      <Text>{`${format.format}, ${format.isbn}`}</Text>
+                      <Text>{`${format.format}, ${format.isbn}, $${format.price}`}</Text>
                     </>
                   ))}
                   <Text>{`Ages ${review.books[currentBook].minAge}-${review.books[currentBook].maxAge}`}</Text>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add Price to Book Review](https://www.notion.so/uwblueprintexecs/Add-Price-to-Book-Review-df963de68c414a908a3bb1569c462a22)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* add price behind book format in review and preview review pages


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. check that price is there in preview review page
2. check that price is there in review page


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
