### PR TITLE
[fix]: add loading spinner to invite admin modal

### DIFF
--- a/frontend/src/components/common/InviteAdminModal.tsx
+++ b/frontend/src/components/common/InviteAdminModal.tsx
@@ -18,6 +18,7 @@ import React, { useState } from "react";
 import authAPIClient from "../../APIClients/AuthAPIClient";
 import { SIGNUP_ERROR } from "../../constants/ErrorMessages";
 import useToasts from "../Toast";
+import LoadingSpinner from "./LoadingSpinner";
 
 export type InviteAdminModalProps = {
   // this describes the state of the modal
@@ -35,6 +36,7 @@ const InviteAdminModal = (props: InviteAdminModalProps): React.ReactElement => {
   const [lastName, setLastName] = useState("");
   const [isInvalid, setIsInvalid] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
 
   const { isOpen, onClose } = props;
   const newToast = useToasts();
@@ -43,11 +45,13 @@ const InviteAdminModal = (props: InviteAdminModalProps): React.ReactElement => {
    * handler function to be executed when the submit button is clicked
    */
   const onSubmitClick = async () => {
+    setIsLoading(true);
     if (!email || !firstName || !lastName) {
       setIsInvalid(true);
       setErrorMessage("Please enter all fields");
     } else {
       const user = await authAPIClient.register(firstName, lastName, email);
+      setIsLoading(false);
       if (!user) {
         setIsInvalid(true);
         setErrorMessage(SIGNUP_ERROR);
@@ -80,63 +84,69 @@ const InviteAdminModal = (props: InviteAdminModalProps): React.ReactElement => {
         pb="40px"
         pt="49px"
       >
-        <ModalHeader mb="0px">Invite New Admin Request</ModalHeader>
-        <ModalCloseButton mt="30px" mr="30px" />
-        <ModalBody>
-          <FormControl>
-            <Box>
-              <FormLabel>First name</FormLabel>
-              <Input
-                value={firstName}
-                name="firstName"
-                placeholder="First name"
-                onChange={(event) => {
-                  setIsInvalid(false);
-                  setFirstName(event.target.value);
-                }}
-              />
-            </Box>
-            <Box mt="4%">
-              <FormLabel>Last name</FormLabel>
-              <Input
-                value={lastName}
-                name="lastName"
-                placeholder="Last name"
-                onChange={(event) => {
-                  setIsInvalid(false);
-                  setLastName(event.target.value);
-                }}
-              />
-            </Box>
-            <Box mt="4%">
-              <FormLabel>Email address</FormLabel>
-              <Input
-                value={email}
-                name="email"
-                type="email"
-                placeholder="Email address"
-                onChange={(event) => {
-                  setIsInvalid(false);
-                  setEmail(event.target.value);
-                }}
-              />
-            </Box>
-            {isInvalid ? (
-              <FormHelperText color="crimson">{errorMessage}</FormHelperText>
-            ) : null}
-          </FormControl>
-        </ModalBody>
+        {isLoading ? (
+          <LoadingSpinner h="20%" />
+        ) : (
+          <>
+            <ModalHeader mb="0px">Invite New Admin Request</ModalHeader>
+            <ModalCloseButton mt="30px" mr="30px" />
+            <ModalBody>
+              <FormControl>
+                <Box>
+                  <FormLabel>First name</FormLabel>
+                  <Input
+                    value={firstName}
+                    name="firstName"
+                    placeholder="First name"
+                    onChange={(event) => {
+                      setIsInvalid(false);
+                      setFirstName(event.target.value);
+                    }}
+                  />
+                </Box>
+                <Box mt="4%">
+                  <FormLabel>Last name</FormLabel>
+                  <Input
+                    value={lastName}
+                    name="lastName"
+                    placeholder="Last name"
+                    onChange={(event) => {
+                      setIsInvalid(false);
+                      setLastName(event.target.value);
+                    }}
+                  />
+                </Box>
+                <Box mt="4%">
+                  <FormLabel>Email address</FormLabel>
+                  <Input
+                    value={email}
+                    name="email"
+                    type="email"
+                    placeholder="Email address"
+                    onChange={(event) => {
+                      setIsInvalid(false);
+                      setEmail(event.target.value);
+                    }}
+                  />
+                </Box>
+                {isInvalid ? (
+                  <FormHelperText color="crimson">{errorMessage}</FormHelperText>
+                ) : null}
+              </FormControl>
+            </ModalBody>
 
-        <ModalFooter justifyContent="flex-start">
-          <Button
-            onClick={onSubmitClick}
-            variant="submit"
-            width="117px"
-            height="40px"
-          >
-            Submit
-          </Button>
-        </ModalFooter>
+            <ModalFooter justifyContent="flex-start">
+              <Button
+                onClick={onSubmitClick}
+                variant="submit"
+                width="117px"
+                height="40px"
+              >
+                Submit
+              </Button>
+            </ModalFooter>
+          </>
+        )}
       </ModalContent>
     </Modal>
   );

--- a/frontend/src/components/common/InviteAdminModal.tsx
+++ b/frontend/src/components/common/InviteAdminModal.tsx
@@ -130,7 +130,9 @@ const InviteAdminModal = (props: InviteAdminModalProps): React.ReactElement => {
                   />
                 </Box>
                 {isInvalid ? (
-                  <FormHelperText color="crimson">{errorMessage}</FormHelperText>
+                  <FormHelperText color="crimson">
+                    {errorMessage}
+                  </FormHelperText>
                 ) : null}
               </FormControl>
             </ModalBody>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Loading Spinner for Invite New AdminPreviewReviewModal](https://www.notion.so/uwblueprintexecs/Loading-Spinner-for-Invite-New-AdminPreviewReviewModal-13d039bb01f0476a93df0d58e7925a67)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* added loading spinner after user submits form

https://user-images.githubusercontent.com/75541476/190526365-b49951e1-bafd-461c-95e3-1b081696003b.mov

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to localhost:3000 and login
2. Click profile icon > Invite new admin
3. Spinner should show when you hit submit


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
