### PR TITLE
bug: hide nav arrows and coloured dot for single books

### DIFF
--- a/frontend/src/components/PreviewReview/PreviewReview.tsx
+++ b/frontend/src/components/PreviewReview/PreviewReview.tsx
@@ -64,7 +64,7 @@ const PreviewReview = ({
           mb="-12px"
           spacing={isPageView ? 20 : 0}
         >
-          {!multiplebooks ? null : (
+          {multiplebooks ? (
             <ChevronLeftIcon
               boxSize="2em"
               style={{
@@ -73,7 +73,7 @@ const PreviewReview = ({
               }}
               onClick={handleLeftClick}
             />
-          )}
+          ) : null}
 
           <Box
             pr={16}
@@ -178,7 +178,7 @@ const PreviewReview = ({
               </Box>
             </Stack>
           </Box>
-          {!multiplebooks ? null : (
+          {multiplebooks ? (
             <ChevronRightIcon
               boxSize="2em"
               style={{
@@ -193,12 +193,11 @@ const PreviewReview = ({
               }}
               onClick={handleRightClick}
             />
-          )}
+          ) : null}
         </HStack>
         <HStack>
-          {!multiplebooks
-            ? null
-            : Array.from(Array(review.books.length).keys()).map((_, index) => (
+          {multiplebooks
+            ? Array.from(Array(review.books.length).keys()).map((_, index) => (
                 <Icon
                   key={index}
                   viewBox="0 0 200 200"
@@ -212,7 +211,8 @@ const PreviewReview = ({
                     d="M 100, 100 m -75, 0 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0"
                   />
                 </Icon>
-              ))}
+              ))
+            : null}
         </HStack>
         <VStack align="flex-start" width={isPageView ? "50%" : "80%"}>
           <Text fontWeight={400} fontSize="12px">

--- a/frontend/src/components/PreviewReview/PreviewReview.tsx
+++ b/frontend/src/components/PreviewReview/PreviewReview.tsx
@@ -34,6 +34,7 @@ const PreviewReview = ({
   isPageView = false,
 }: PreviewReviewProps): React.ReactElement => {
   const [currentBook, setCurrentBook] = useState<number>(0);
+  const multiplebooks = review.books.length > 1;
 
   // sort books based on series order
   review.books.sort((a, b) => {
@@ -63,14 +64,17 @@ const PreviewReview = ({
           mb="-12px"
           spacing={isPageView ? 20 : 0}
         >
-          <ChevronLeftIcon
-            boxSize="2em"
-            style={{
-              cursor: `${currentBook !== 0 ? "pointer" : "auto"}`,
-              color: `${currentBook !== 0 ? "black" : "lightgray"}`,
-            }}
-            onClick={handleLeftClick}
-          />
+          {!multiplebooks ? null : (
+            <ChevronLeftIcon
+              boxSize="2em"
+              style={{
+                cursor: `${currentBook !== 0 ? "pointer" : "auto"}`,
+                color: `${currentBook !== 0 ? "black" : "lightgray"}`,
+              }}
+              onClick={handleLeftClick}
+            />
+          )}
+
           <Box
             pr={16}
             pl={16}
@@ -174,35 +178,41 @@ const PreviewReview = ({
               </Box>
             </Stack>
           </Box>
-          <ChevronRightIcon
-            boxSize="2em"
-            style={{
-              cursor: `${
-                currentBook !== review.books.length - 1 ? "pointer" : "auto"
-              }`,
-              color: `${
-                currentBook !== review.books.length - 1 ? "black" : "lightgray"
-              }`,
-            }}
-            onClick={handleRightClick}
-          />
+          {!multiplebooks ? null : (
+            <ChevronRightIcon
+              boxSize="2em"
+              style={{
+                cursor: `${
+                  currentBook !== review.books.length - 1 ? "pointer" : "auto"
+                }`,
+                color: `${
+                  currentBook !== review.books.length - 1
+                    ? "black"
+                    : "lightgray"
+                }`,
+              }}
+              onClick={handleRightClick}
+            />
+          )}
         </HStack>
         <HStack>
-          {Array.from(Array(review.books.length).keys()).map((_, index) => (
-            <Icon
-              key={index}
-              viewBox="0 0 200 200"
-              onClick={() => setCurrentBook(index)}
-              style={{ cursor: "pointer" }}
-            >
-              <path
-                fill={`${index === currentBook ? "black" : "none"}`}
-                stroke="black"
-                strokeWidth="12"
-                d="M 100, 100 m -75, 0 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0"
-              />
-            </Icon>
-          ))}
+          {!multiplebooks
+            ? null
+            : Array.from(Array(review.books.length).keys()).map((_, index) => (
+                <Icon
+                  key={index}
+                  viewBox="0 0 200 200"
+                  onClick={() => setCurrentBook(index)}
+                  style={{ cursor: "pointer" }}
+                >
+                  <path
+                    fill={`${index === currentBook ? "black" : "none"}`}
+                    stroke="black"
+                    strokeWidth="12"
+                    d="M 100, 100 m -75, 0 a 75,75 0 1,0 150,0 a 75,75 0 1,0 -150,0"
+                  />
+                </Icon>
+              ))}
         </HStack>
         <VStack align="flex-start" width={isPageView ? "50%" : "80%"}>
           <Text fontWeight={400} fontSize="12px">


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Previewing a Single Book](https://www.notion.so/uwblueprintexecs/Previewing-a-Single-Book-f510c07114eb4de9b153971f1305bf9f)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* To hide nav arrows and coloured dots for single books (ie not a book series), I used conditional rendering with review.books.length to check if it was a single book and render/hide the appropriate components.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.  Go to Admin Dashboard
2. Preview a review (click the eye)
3. Check both book series and single books. Single books should not have arrows or dots but the spacing should be the same as book series. For a visual, view the ticket on notion. The highlighted areas in the photo should not be visible for single books.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Correct implementation & DRY as much as I can


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
