### PR TITLE
Block Subscribers from Viewing Drafts

### DIFF
--- a/backend/typescript/rest/reviewRoutes.ts
+++ b/backend/typescript/rest/reviewRoutes.ts
@@ -9,7 +9,11 @@ import {
 import { getErrorMessage, sendErrorResponse } from "../utilities/errorResponse";
 import sendResponseByMimeType from "../utilities/responseUtil";
 import reviewRequestDtoValidator from "../middlewares/validators/reviewValidators";
-import { getAccessToken, isAuthorizedByUserId, isAuthorizedByRole } from "../middlewares/auth";
+import {
+  getAccessToken,
+  isAuthorizedByUserId,
+  isAuthorizedByRole,
+} from "../middlewares/auth";
 import AuthService from "../services/implementations/authService";
 import IAuthService from "../services/interfaces/authService";
 import UserService from "../services/implementations/userService";
@@ -56,7 +60,11 @@ reviewRouter.get(
       if (review.publishedAt == null) {
         const accessToken = getAccessToken(req);
         const isAdmin =
-          accessToken && (await authService.isAuthorizedByRole(accessToken, new Set(["Admin"])));
+          accessToken &&
+          (await authService.isAuthorizedByRole(
+            accessToken,
+            new Set(["Admin"]),
+          ));
         if (isAdmin) {
           res.status(200).json(review);
         } else {
@@ -90,8 +98,9 @@ reviewRouter.get(
     try {
       const accessToken = getAccessToken(req);
       const isAdmin =
-        accessToken && (await authService.isAuthorizedByRole(accessToken, new Set(["Admin"])));
-      let draft = req.query.draft;
+        accessToken &&
+        (await authService.isAuthorizedByRole(accessToken, new Set(["Admin"])));
+      let { draft } = req.query;
       if (!isAdmin) {
         draft = "false";
       }

--- a/backend/typescript/rest/reviewRoutes.ts
+++ b/backend/typescript/rest/reviewRoutes.ts
@@ -9,10 +9,14 @@ import {
 import { getErrorMessage, sendErrorResponse } from "../utilities/errorResponse";
 import sendResponseByMimeType from "../utilities/responseUtil";
 import reviewRequestDtoValidator from "../middlewares/validators/reviewValidators";
-import { isAuthorizedByUserId, isAuthorizedByRole } from "../middlewares/auth";
+import { getAccessToken, isAuthorizedByUserId, isAuthorizedByRole } from "../middlewares/auth";
+import AuthService from "../services/implementations/authService";
+import IAuthService from "../services/interfaces/authService";
+import UserService from "../services/implementations/userService";
 
 const reviewRouter: Router = Router();
 const reviewService: IReviewService = new ReviewService();
+const authService: IAuthService = new AuthService(new UserService());
 
 reviewRouter.post(
   "/",
@@ -49,7 +53,20 @@ reviewRouter.get(
     const { id } = req.params;
     try {
       const review = await reviewService.getReview(id);
-      res.status(200).json(review);
+      if (review.publishedAt == null) {
+        const accessToken = getAccessToken(req);
+        const isAdmin =
+          accessToken && (await authService.isAuthorizedByRole(accessToken, new Set(["Admin"])));
+        if (isAdmin) {
+          res.status(200).json(review);
+        } else {
+          // this response should be identical to the one in reviewService,
+          // otherwise the attacker can deduce that this is a draft id.
+          sendErrorResponse(new Error(`Review id ${id} not found`), res);
+        }
+      } else {
+        res.status(200).json(review);
+      }
     } catch (e: unknown) {
       sendErrorResponse(e, res);
     }
@@ -68,9 +85,17 @@ reviewRouter.get(
       ? (req.query.genres as string).split(",")
       : [];
 
-    const { minAge, maxAge, featured, draft } = req.query;
+    const { minAge, maxAge, featured } = req.query;
 
     try {
+      const accessToken = getAccessToken(req);
+      const isAdmin =
+        accessToken && (await authService.isAuthorizedByRole(accessToken, new Set(["Admin"])));
+      let draft = req.query.draft;
+      if (!isAdmin) {
+        draft = "false";
+      }
+
       const reviewsData = await reviewService.getReviews(
         page,
         size,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Block Subscribers from Viewing Drafts](https://www.notion.so/uwblueprintexecs/Block-Subscribers-from-Viewing-Drafts-3789f3e949c14c78a132983a91eee967)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Use auth service to check a user's role when they are attempting to view an individual draft. Also filter out drafts when users are not admins and they hit `/reviews`


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Seed database with drafts and published reviews
2. Make an admin account & non admin account
3. Attempt to view a draft as admin and non admin by `/review/:id`. The non admin should get a 404 and the admin should get the draft
4. View all the results in `/reviews`. For a non admin drafts should be filtered out but pages should still have full capacity (filtering should be done BEFORE pagination). For admins they should simply recieve all reviews.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Code style. This is my first PR & term on blueprint so I am not 100% sure of the conventions. I tried to match what the repository currently does by looking at the code.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
