### PR TITLE
[Bug] Apply search when going back to search page 

### DIFF
--- a/frontend/src/components/pages/SearchReviews/SearchReviews.tsx
+++ b/frontend/src/components/pages/SearchReviews/SearchReviews.tsx
@@ -18,7 +18,7 @@ import ReviewsGrid from "./ReviewsGrid";
  *    ageRange: the age range filter applied to search, in the format of "minAge,maxAge" i.e "5,10"
  */
 const SearchReviews = (): React.ReactElement => {
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
   const [searchText, setSearchText] = useState<string>("");
   const [genresFilter, setGenresFilter] = useState<string[]>([]);
   const [ageRangeFilter, setAgeRangeFilter] = useState<number[]>([]); // ageRange[0] is min age, ageRange[1] is max age
@@ -46,6 +46,7 @@ const SearchReviews = (): React.ReactElement => {
     if (intAgeRange) {
       setAgeRangeFilter(intAgeRange);
     }
+    setLoading(false);
   }, []);
 
   /** Creates new url based on search text and filters */
@@ -67,6 +68,7 @@ const SearchReviews = (): React.ReactElement => {
 
   /** Changes url to when search filters are changed and fetches search results  */
   useEffect(() => {
+    if (loading) return;
     setLoading(true);
     const newSearchUrl = generateSearchUrl(
       searchText,


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Going Back to Search Page doesn’t apply search/filter query properly](https://www.notion.so/uwblueprintexecs/Going-Back-to-Search-Page-doesn-t-apply-search-filter-query-properly-c9e5392b712146efa85df701fe3f34b5)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
*  Use the loading hook to make sure that the reviews does not update twice
* Set the loading hook to true at first, and not call the review API without rendering the URL search params


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Search for something
2. Observe the returned results
3. Click on a review
4. Click on “Go Back”
5. The search box will still be pre-filled with the search query from earlier, but the results will not match that search query
6. Refreshing the page fixes it


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Try the search with various books 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
