### PR TITLE
[Fix]: add genre seeding scripts

### DIFF
--- a/backend/typescript/migrations/20220715012943-change-book-tag-book-genre-constraints-to-cascade.js
+++ b/backend/typescript/migrations/20220715012943-change-book-tag-book-genre-constraints-to-cascade.js
@@ -1,89 +1,90 @@
 module.exports = {
   async up(queryInterface, Sequelize) {
-    const removeTagNameTransaction = queryInterface.sequelize.transaction(async (t) => {
-      try {
+    const removeTagNameTransaction = queryInterface.sequelize.transaction(
+      async (t) => {
+        try {
+          await queryInterface.removeConstraint(
+            "book_tag",
+            "book_tag_tag_name_fkey",
+            { transaction: t },
+          );
+        } catch (e) {
+          console.warn(e);
+        }
+      },
+    );
+
+    const everythingElseTransaction = queryInterface.sequelize.transaction(
+      async (t) => {
+        // Remove previous constraints
         await queryInterface.removeConstraint(
           "book_tag",
-          "book_tag_tag_name_fkey",
+          "book_tag_book_id_fkey",
           { transaction: t },
         );
-      } catch (e) {
-        console.warn(e);
-      }
-    })
-    
-    const everythingElseTransaction = queryInterface.sequelize.transaction(async (t) => {
-      // Remove previous constraints
-      await queryInterface.removeConstraint(
-        "book_tag",
-        "book_tag_book_id_fkey",
-        { transaction: t },
-      );
-      await queryInterface.removeConstraint(
-        "book_genre",
-        "book_genre_book_id_fkey",
-        { transaction: t },
-      );
-      await queryInterface.removeConstraint(
-        "book_genre",
-        "book_genre_genre_name_fkey",
-        { transaction: t },
-      );
-      // Add new constraints with cascade
-      await queryInterface.addConstraint("book_tag", {
-        fields: ["book_id"],
-        type: "foreign key",
-        name: "book_tag_book_id_fkey",
-        references: {
-          table: "books",
-          field: "id",
-        },
-        onDelete: "CASCADE",
-        onUpdate: "CASCADE",
-        transaction: t,
-      });
-      await queryInterface.addConstraint("book_tag", {
-        fields: ["tag_name"],
-        type: "foreign key",
-        name: "book_tag_tag_name_fkey",
-        references: {
-          table: "tags",
-          field: "name",
-        },
-        onDelete: "CASCADE",
-        onUpdate: "CASCADE",
-        transaction: t,
-      });
-      await queryInterface.addConstraint("book_genre", {
-        fields: ["book_id"],
-        type: "foreign key",
-        name: "book_genre_book_id_fkey",
-        references: {
-          table: "books",
-          field: "id",
-        },
-        onDelete: "CASCADE",
-        onUpdate: "CASCADE",
-        transaction: t,
-      });
-      await queryInterface.addConstraint("book_genre", {
-        fields: ["genre_name"],
-        type: "foreign key",
-        name: "book_genre_genre_name_fkey",
-        references: {
-          table: "genres",
-          field: "name",
-        },
-        onDelete: "CASCADE",
-        onUpdate: "CASCADE",
-        transaction: t,
-      });
-    });
+        await queryInterface.removeConstraint(
+          "book_genre",
+          "book_genre_book_id_fkey",
+          { transaction: t },
+        );
+        await queryInterface.removeConstraint(
+          "book_genre",
+          "book_genre_genre_name_fkey",
+          { transaction: t },
+        );
+        // Add new constraints with cascade
+        await queryInterface.addConstraint("book_tag", {
+          fields: ["book_id"],
+          type: "foreign key",
+          name: "book_tag_book_id_fkey",
+          references: {
+            table: "books",
+            field: "id",
+          },
+          onDelete: "CASCADE",
+          onUpdate: "CASCADE",
+          transaction: t,
+        });
+        await queryInterface.addConstraint("book_tag", {
+          fields: ["tag_name"],
+          type: "foreign key",
+          name: "book_tag_tag_name_fkey",
+          references: {
+            table: "tags",
+            field: "name",
+          },
+          onDelete: "CASCADE",
+          onUpdate: "CASCADE",
+          transaction: t,
+        });
+        await queryInterface.addConstraint("book_genre", {
+          fields: ["book_id"],
+          type: "foreign key",
+          name: "book_genre_book_id_fkey",
+          references: {
+            table: "books",
+            field: "id",
+          },
+          onDelete: "CASCADE",
+          onUpdate: "CASCADE",
+          transaction: t,
+        });
+        await queryInterface.addConstraint("book_genre", {
+          fields: ["genre_name"],
+          type: "foreign key",
+          name: "book_genre_genre_name_fkey",
+          references: {
+            table: "genres",
+            field: "name",
+          },
+          onDelete: "CASCADE",
+          onUpdate: "CASCADE",
+          transaction: t,
+        });
+      },
+    );
 
-    return Promise.all([
-      removeTagNameTransaction,
-      everythingElseTransaction
-    ])
+    return Promise.all([removeTagNameTransaction, everythingElseTransaction]);
   },
 
   async down(queryInterface, Sequelize) {

--- a/backend/typescript/seeders/2022.09.29T23.08.12.sample-genres.ts
+++ b/backend/typescript/seeders/2022.09.29T23.08.12.sample-genres.ts
@@ -1,0 +1,35 @@
+import { Seeder } from "../umzug";
+
+const seedGenres = [
+  {
+    name: "Fantasy",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    name: "Mystery",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    name: "Horror",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    name: "Science Fiction",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+];
+
+export const up: Seeder = async ({ context: sequelize }) => {
+  await sequelize.query("TRUNCATE TABLE genres CASCADE");
+  await sequelize.getQueryInterface().bulkInsert("genres", seedGenres);
+};
+
+export const down: Seeder = async ({ context: sequelize }) => {
+  await sequelize
+    .getQueryInterface()
+    .bulkDelete("genres", { name: seedGenres.map((u) => u.name) });
+};

--- a/backend/typescript/seeders/2022.09.29T23.22.12.sample-book-genres.ts
+++ b/backend/typescript/seeders/2022.09.29T23.22.12.sample-book-genres.ts
@@ -1,0 +1,93 @@
+import { Seeder } from "../umzug";
+
+const seedGenres = [
+  {
+    book_id: 1,
+    genre_name: "Fantasy",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    book_id: 2,
+    genre_name: "Mystery",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    book_id: 3,
+    genre_name: "Horror",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    book_id: 4,
+    genre_name: "Science Fiction",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    book_id: 5,
+    genre_name: "Fantasy",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    book_id: 6,
+    genre_name: "Mystery",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    book_id: 7,
+    genre_name: "Horror",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    book_id: 8,
+    genre_name: "Science Fiction",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    book_id: 9,
+    genre_name: "Fantasy",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    book_id: 10,
+    genre_name: "Mystery",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    book_id: 11,
+    genre_name: "Horror",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    book_id: 12,
+    genre_name: "Science Fiction",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+  {
+    book_id: 13,
+    genre_name: "Fantasy",
+    createdAt: new Date(Date.now()),
+    updatedAt: new Date(Date.now()),
+  },
+];
+
+export const up: Seeder = async ({ context: sequelize }) => {
+  await sequelize.query("TRUNCATE TABLE book_genre CASCADE");
+  await sequelize.getQueryInterface().bulkInsert("book_genre", seedGenres);
+};
+
+export const down: Seeder = async ({ context: sequelize }) => {
+  await sequelize
+    .getQueryInterface()
+    .bulkDelete("book_genre", { book_id: seedGenres.map((u) => u.book_id) });
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[BUG: Intersecting age intervals](https://www.notion.so/uwblueprintexecs/BUG-Intersecting-age-intervals-08ba73a0e5c84f67b507989057ea88c1)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* The age bug was actually an error with a missing genres and book_genres table so this ticket instead adds seeding scripts to fill the table

<img width="956" alt="image" src="https://user-images.githubusercontent.com/75541476/193159806-9f9ab2bc-b8c0-479e-880c-911c9fa1d395.png">

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Visit the home page
2. Ensure books are visible for age 4-8 and 9-12 but not 0-3


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Anything unusual with details of the seeding script


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
