### PR TITLE
[FIX]: Fixed email verification for non-admin users

### DIFF
--- a/backend/typescript/middlewares/validators/userValidators.ts
+++ b/backend/typescript/middlewares/validators/userValidators.ts
@@ -16,8 +16,8 @@ export const createUserDtoValidator = async (
     return res.status(400).send(getApiValidationError("email", "string"));
   }
   if (
-    req.body.roleType !== "Admin" ||
-    req.body.roleType !== "Subscriber" ||
+    req.body.roleType !== "Admin" &&
+    req.body.roleType !== "Subscriber" &&
     req.body.roleType !== "Author"
   ) {
     return res.status(400).send(getApiValidationError("roleType", "Role"));

--- a/backend/typescript/rest/userRoutes.ts
+++ b/backend/typescript/rest/userRoutes.ts
@@ -87,11 +87,11 @@ userRouter.post("/", createUserDtoValidator, async (req, res) => {
     const { firstName, lastName, email, roleType } = req.body;
 
     const newUser = await authService.createUserAndSendRegistrationEmail(
-      firstName, 
-      lastName, 
-      email, 
-      roleType, 
-      null
+      firstName,
+      lastName,
+      email,
+      roleType,
+      null,
     );
 
     res.status(201).json(newUser);

--- a/backend/typescript/rest/userRoutes.ts
+++ b/backend/typescript/rest/userRoutes.ts
@@ -84,16 +84,15 @@ userRouter.get("/", async (req, res) => {
 /* Create a user */
 userRouter.post("/", createUserDtoValidator, async (req, res) => {
   try {
-    const newUser = await userService.createUser({
-      firstName: req.body.firstName,
-      lastName: req.body.lastName,
-      email: req.body.email,
-      roleType: req.body.roleType,
-      password: req.body.password,
-      subscriptionExpiresOn: null,
-    });
+    const { firstName, lastName, email, roleType } = req.body;
 
-    await authService.sendEmailVerificationLink(req.body.email);
+    const newUser = await authService.createUserAndSendRegistrationEmail(
+      firstName, 
+      lastName, 
+      email, 
+      roleType, 
+      null
+    );
 
     res.status(201).json(newUser);
   } catch (error: unknown) {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Broken email verification for non-admin user](https://www.notion.so/uwblueprintexecs/16fb020b93f641c8b384f76a1b3c769e?v=aedc8d99cd8b437cb556ece10f3c0e3c&p=f995dbc4dd314a8a82c31785425deeba&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* rerouted post method of creating a non-admin user to use the same set of functions as creating a new admin


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a non-admin user through the post route in userServices
2. Click on the email link and see if it goes through the signup process flow as usual


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Changed function for handling post route "/"


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR

https://user-images.githubusercontent.com/55671206/194438333-4cfb5c7e-f131-4f20-8027-c14125df3e9a.mov


https://user-images.githubusercontent.com/55671206/194438510-39ec9c89-eaf9-441b-ab71-4c0cdc68fcb3.mov

