### PR TITLE
[Feat] Close user registration route to admins only 

### DIFF
--- a/backend/typescript/middlewares/auth.ts
+++ b/backend/typescript/middlewares/auth.ts
@@ -35,7 +35,6 @@ export const isAuthorizedByRole = (roles: Set<Role>) => {
         .status(401)
         .json({ error: "You are not authorized to make this request." });
     }
-    // user cannot be null, since this would be catched by isAuthorizedByRole
     const user: User | null = await authService.getUserByAccessToken(
       accessToken,
     );

--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -1,6 +1,10 @@
 import { Router } from "express";
 
-import { isAuthorizedByEmail, isAuthorizedByUserId } from "../middlewares/auth";
+import {
+  isAuthorizedByEmail,
+  isAuthorizedByRole,
+  isAuthorizedByUserId,
+} from "../middlewares/auth";
 import {
   loginRequestValidator,
   registerRequestValidator,
@@ -54,23 +58,28 @@ authRouter.get("/:uid", async (req, res) => {
 });
 
 /* Register a user, returns access token and user info in response body and sets refreshToken as an httpOnly cookie */
-authRouter.post("/register", registerRequestValidator, async (req, res) => {
-  try {
-    const { firstName, lastName, email } = req.body;
+authRouter.post(
+  "/register",
+  isAuthorizedByRole(new Set(["Admin"])),
+  registerRequestValidator,
+  async (req, res) => {
+    try {
+      const { firstName, lastName, email } = req.body;
 
-    const authDTO = await authService.createUserAndSendRegistrationEmail(
-      firstName,
-      lastName,
-      email,
-      "Admin",
-      null,
-    );
+      const authDTO = await authService.createUserAndSendRegistrationEmail(
+        firstName,
+        lastName,
+        email,
+        "Admin",
+        null,
+      );
 
-    res.status(200).json(authDtoToToUserDto(authDTO));
-  } catch (error: unknown) {
-    sendErrorResponse(error, res);
-  }
-});
+      res.status(200).json(authDtoToToUserDto(authDTO));
+    } catch (error: unknown) {
+      sendErrorResponse(error, res);
+    }
+  },
+);
 
 /* Sends the user an email to reset their password. Used when the user has forgotten their password */
 authRouter.post("/forgotPassword", async (req, res) => {

--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -62,11 +62,15 @@ const register = async (
   lastName: string,
   email: string,
 ): Promise<AuthenticatedUser> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
   try {
     const { data } = await baseAPIClient.post(
       "/auth/register",
       { firstName, lastName, email },
-      { withCredentials: true },
+      { withCredentials: true, headers: { Authorization: bearerToken }},
     );
     return data;
   } catch (error) {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Close user registration route to admins only ](https://www.notion.so/uwblueprintexecs/Close-user-registration-route-to-admins-only-251b4e1ff7014ea6bb514db89f5754a5)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added isAuthorizedByRole as middleware for the register route 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Test that you can register other uses with an admin user
2. Test that you cannot register other users with any other role


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
*  the response code


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
