### PR TITLE
revoke keys based off of subscription expiry date

### DIFF
--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -101,6 +101,12 @@ authRouter.post("/refresh", async (req, res) => {
   try {
     const token = await authService.renewToken(req.cookies.refreshToken);
 
+    if (token.accessToken === "") {
+      return res
+        .status(401)
+        .json({ error: "You are not authorized to make this request." });
+    }
+
     res
       .cookie("refreshToken", token.refreshToken, {
         httpOnly: true,

--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -107,7 +107,7 @@ authRouter.post("/refresh", async (req, res) => {
         .json({ error: "You are not authorized to make this request." });
     }
 
-    res
+    return res
       .cookie("refreshToken", token.refreshToken, {
         httpOnly: true,
         sameSite: "none",

--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -25,7 +25,7 @@ authRouter.post("/login", loginRequestValidator, async (req, res) => {
   try {
     const authDTO = req.body.idToken
       ? // OAuth
-        await authService.generateTokenOAuth(req.body.idToken)
+      await authService.generateTokenOAuth(req.body.idToken)
       : await authService.generateToken(req.body.email, req.body.password);
 
     const { refreshToken, ...rest } = authDTO;

--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -102,24 +102,21 @@ authRouter.post("/refresh", async (req, res) => {
     const token = await authService.renewToken(req.cookies.refreshToken);
 
     if (token.accessToken === "") {
-      return res
+      res
         .status(401)
         .json({ error: "You are not authorized to make this request." });
+    } else {
+      res
+        .cookie("refreshToken", token.refreshToken, {
+          httpOnly: true,
+          sameSite: "none",
+          secure: process.env.NODE_ENV === "production",
+        })
+        .status(200)
+        .json({ accessToken: token.accessToken });
     }
-
-    res
-      .cookie("refreshToken", token.refreshToken, {
-        httpOnly: true,
-        sameSite: "none",
-        secure: process.env.NODE_ENV === "production",
-      })
-      .status(200)
-      .json({ accessToken: token.accessToken });
   } catch (error: unknown) {
     sendErrorResponse(error, res);
-    return res
-      .status(401)
-      .json({ error: "An error has occurred." });
   }
 });
 

--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -107,7 +107,7 @@ authRouter.post("/refresh", async (req, res) => {
         .json({ error: "You are not authorized to make this request." });
     }
 
-    return res
+    res
       .cookie("refreshToken", token.refreshToken, {
         httpOnly: true,
         sameSite: "none",
@@ -117,6 +117,9 @@ authRouter.post("/refresh", async (req, res) => {
       .json({ accessToken: token.accessToken });
   } catch (error: unknown) {
     sendErrorResponse(error, res);
+    return res
+      .status(401)
+      .json({ error: "An error has occurred." });
   }
 });
 

--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -25,7 +25,7 @@ authRouter.post("/login", loginRequestValidator, async (req, res) => {
   try {
     const authDTO = req.body.idToken
       ? // OAuth
-      await authService.generateTokenOAuth(req.body.idToken)
+        await authService.generateTokenOAuth(req.body.idToken)
       : await authService.generateToken(req.body.email, req.body.password);
 
     const { refreshToken, ...rest } = authDTO;

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -56,7 +56,7 @@ class AuthService implements IAuthService {
         const user = await this.userService.getUserByEmail(googleUser.email);
         return { ...token, ...user };
         /* eslint-disable no-empty */
-      } catch (error) { }
+      } catch (error) {}
 
       const user = await this.userService.createUser(
         {

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -101,8 +101,6 @@ class AuthService implements IAuthService {
     try {
       const ret = await FirebaseRestClient.refreshToken(refreshToken);
       const user = await this.getUserByAccessToken(ret.accessToken);
-
-      console.log(ret.accessToken);
       
       if (user && user.subscription_expires_on) {
         const currentDate = new Date();

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -56,7 +56,7 @@ class AuthService implements IAuthService {
         const user = await this.userService.getUserByEmail(googleUser.email);
         return { ...token, ...user };
         /* eslint-disable no-empty */
-      } catch (error) {}
+      } catch (error) { }
 
       const user = await this.userService.createUser(
         {
@@ -101,7 +101,7 @@ class AuthService implements IAuthService {
     try {
       const ret = await FirebaseRestClient.refreshToken(refreshToken);
       const user = await this.getUserByAccessToken(ret.accessToken);
-      
+
       if (user && user.subscription_expires_on) {
         const currentDate = new Date();
         currentDate.setUTCHours(0, 0, 0, 0);
@@ -110,7 +110,7 @@ class AuthService implements IAuthService {
 
         if (currentDate.getTime() > subscriptionExpireDate.getTime()) {
           await this.revokeTokens(user.id);
-          return {accessToken: "", refreshToken: ""};
+          return { accessToken: "", refreshToken: "" };
         }
       }
 

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -99,7 +99,24 @@ class AuthService implements IAuthService {
   /* eslint-disable class-methods-use-this */
   async renewToken(refreshToken: string): Promise<Token> {
     try {
-      return await FirebaseRestClient.refreshToken(refreshToken);
+      const ret = await FirebaseRestClient.refreshToken(refreshToken);
+      const user = await this.getUserByAccessToken(ret.accessToken);
+
+      console.log(ret.accessToken);
+      
+      if (user && user.subscription_expires_on) {
+        const currentDate = new Date();
+        currentDate.setUTCHours(0, 0, 0, 0);
+        const subscriptionExpireDate = new Date(user.subscription_expires_on);
+        subscriptionExpireDate.setUTCHours(0, 0, 0, 0);
+
+        if (currentDate.getTime() > subscriptionExpireDate.getTime()) {
+          await this.revokeTokens(user.id);
+          return {accessToken: "", refreshToken: ""};
+        }
+      }
+
+      return ret;
     } catch (error) {
       Logger.error("Failed to refresh token");
       throw error;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Invalidate tokens for expired subscriptions](https://www.notion.so/uwblueprintexecs/Invalidate-tokens-for-expired-subscriptions-9dc0cf5a7b184fb9828b01bd2b479e52)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Check if the subscription expiry date is earlier than current date on refresh and if it is, revoke the token.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Login with an admin user account
2. Make a put request to the /users/:userid with your id with the subscription day earlier than current date (some changes to the put route and uservalidators may need to be made for this put request to work)
3. Make a post request to /auth/refresh
4. Check that the token is revoked


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have run docker-compose up and my project compiled
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
