### PR TITLE
[Feat]: Added ordered/unordered series for books

### DIFF
--- a/frontend/src/components/PreviewReview/PreviewInfo.tsx
+++ b/frontend/src/components/PreviewReview/PreviewInfo.tsx
@@ -32,6 +32,9 @@ const PreviewInfo = ({
             {review.books[currentBook].seriesName && (
               <Text fontSize={12}>
                 {review.books[currentBook].seriesName}
+                {review.books[currentBook].seriesOrder > 0
+                  ? ` - ${review.books[currentBook].seriesOrder}`
+                  : ""}
               </Text>
             )}
           </Stack>

--- a/frontend/src/components/pages/CreateReview/BookModal.tsx
+++ b/frontend/src/components/pages/CreateReview/BookModal.tsx
@@ -1,6 +1,7 @@
 import { CheckIcon, SmallCloseIcon } from "@chakra-ui/icons";
 import {
   Button,
+  Checkbox,
   FormControl,
   FormErrorMessage,
   FormLabel,
@@ -90,7 +91,8 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
 
   // optional book fields
   const [seriesName, setSeriesName] = useState<string>("");
-  const [seriesOrder, setSeriesOrder] = useState<number>(1);
+  const [isOrdered, setIsOrdered] = useState(false);
+  const [seriesOrder, setSeriesOrder] = useState<number>(0);
   const [illustrators, setIllustrator] = useState<string[]>([]);
   const [translators, setTranslator] = useState<string[]>([]);
   const [tags, setTags] = useState<Option[]>([]);
@@ -131,7 +133,7 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
       setTitle("");
       setCoverImage("");
       setPrefix("");
-      setSeriesOrder(1);
+      setSeriesOrder(0);
       setIllustrator([]);
       setTranslator([]);
       setGenres([]);
@@ -152,7 +154,7 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
       setTitle(book.title);
       setCoverImage(book.coverImage);
       setPrefix(book.titlePrefix ? book.titlePrefix : "");
-      setSeriesOrder(book.seriesOrder ? book.seriesOrder : 1);
+      setSeriesOrder(book.seriesOrder);
       setIllustrator(book.illustrator);
       setTranslator(book.translator ? book.translator : []);
 
@@ -224,6 +226,7 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
     publisher !== "" &&
     publicationYear !== "" &&
     coverImage !== "" &&
+    (!isOrdered || (isOrdered && seriesOrder > 0 && seriesName !== "")) &&
     // genre !== "" &&
     minAge >= 0 &&
     maxAge >= 0 &&
@@ -344,24 +347,39 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
                     id="seriesName"
                     label="Series"
                     name="series-name"
-                    required={false}
+                    required={isOrdered}
                     inputFieldValue={seriesName}
                     setInputField={setSeriesName}
                   />
-                  <div>
-                    <FormLabel mb={2}>Book number</FormLabel>
-                    <AddNumberInput
-                      placeholder="Book number"
-                      mb={1}
-                      numberInputFieldValue={
-                        seriesOrder >= 1 ? seriesOrder : ""
-                      }
-                      setNumberField={setSeriesOrder}
-                      minNum={kMinBookNum}
-                      maxNum={kMaxBookNum}
-                    />
-                  </div>
+                  {isOrdered ? (
+                    <div>
+                      <FormLabel mb={2}>
+                        Book number
+                        <span style={{ color: "red" }}> * </span>
+                      </FormLabel>
+                      <AddNumberInput
+                        placeholder="#"
+                        mb={1}
+                        numberInputFieldValue={
+                          seriesOrder >= 1 ? seriesOrder : ""
+                        }
+                        setNumberField={setSeriesOrder}
+                        minNum={kMinBookNum}
+                        maxNum={kMaxBookNum}
+                      />
+                    </div>
+                  ) : null}
                 </Stack>
+                <Checkbox
+                  isChecked={isOrdered}
+                  onChange={(e) => {
+                    if (!e.target.checked) setSeriesOrder(0);
+                    else setSeriesOrder(1);
+                    setIsOrdered(e.target.checked);
+                  }}
+                >
+                  Ordered
+                </Checkbox>
                 <AddStringInputList
                   id="authors"
                   label="Author"

--- a/frontend/src/components/pages/SearchReviews/mockReviews.ts
+++ b/frontend/src/components/pages/SearchReviews/mockReviews.ts
@@ -6,7 +6,7 @@ const mockGenericBookData: Book = {
   coverImage:
     "https://images-na.ssl-images-amazon.com/images/I/81drfTT9ZfL.jpg",
   titlePrefix: null,
-  seriesOrder: null,
+  seriesOrder: 0,
   illustrator: ["Dr. Seuss"],
   translator: null,
   formats: [],
@@ -26,7 +26,7 @@ const mockLongTitleBookData: Book = {
   coverImage:
     "https://upload.wikimedia.org/wikipedia/en/thumb/5/51/Spy_Family_vol_1.jpg/220px-Spy_Family_vol_1.jpg",
   titlePrefix: null,
-  seriesOrder: null,
+  seriesOrder: 0,
   illustrator: ["Mangaka"],
   translator: null,
   formats: [],

--- a/frontend/src/types/BookTypes.ts
+++ b/frontend/src/types/BookTypes.ts
@@ -53,7 +53,7 @@ export type Book = {
   title: string;
   coverImage: string;
   titlePrefix: string | null;
-  seriesOrder: number | null;
+  seriesOrder: number;
   illustrator: string[];
   translator: string[] | null;
   formats: BookFormat[];

--- a/frontend/src/types/ReviewTypes.ts
+++ b/frontend/src/types/ReviewTypes.ts
@@ -32,7 +32,7 @@ export type BookRequest = {
   title: string;
   coverImage: string;
   titlePrefix?: string | null;
-  seriesOrder?: number | null;
+  seriesOrder?: number;
   illustrator?: string[] | null;
   translator?: string[] | null;
   formats: Format[] | null;
@@ -50,7 +50,7 @@ export type BookResponse = {
   title: string;
   coverImage: string;
   titlePrefix: string | null;
-  seriesOrder: number | null;
+  seriesOrder: number;
   illustrator: string[] | null;
   translator: string[] | null;
   formats: Format[] | null;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Unordered and Ordered Series](https://www.notion.so/uwblueprintexecs/16fb020b93f641c8b384f76a1b3c769e?v=aedc8d99cd8b437cb556ece10f3c0e3c&p=3b3ba30ae8054e92a5cb9009f7ff8aa5&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* changes seriesOrder prop for book type where 0 means it is unordered and any other number indicates its order in the series
default behaviours:
* if ordered button is selected, series name and series number become required fields in the form
* if ordered button is deselected, the series order for that book is set to 0 and series name is no longer a required field


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a book review
2. Fill in required fields
3. Toggle on Ordered Field and see if form is submittable without Series Name and Order

Unordered Series
<img width="670" alt="image" src="https://user-images.githubusercontent.com/55671206/200442145-d9ce17ed-eb18-41b2-b283-89c4d1f6f39a.png">

Ordered Series
<img width="854" alt="image" src="https://user-images.githubusercontent.com/55671206/200442203-c5c9b77e-948a-44fa-9e65-98d232d9baf2.png">
<img width="667" alt="image" src="https://user-images.githubusercontent.com/55671206/200442237-083838a3-7b89-4e0d-9154-14d9aca6e8b2.png">


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* the default behaviours I described above might not be how we want it to act


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
