### PR TITLE
[Feat]: add creator finish profile flow

### DIFF
--- a/backend/typescript/services/interfaces/creatorService.ts
+++ b/backend/typescript/services/interfaces/creatorService.ts
@@ -38,6 +38,13 @@ interface ICreatorService {
    * @throws Error if creating a creator fails
    */
   createCreator(creator: CreatorCreateUpdateDTO): Promise<void>;
+
+  /**
+   * Sends a link to the creator profile setup page to the creator with the given email
+   * @param email email of creator that will be setting up their profile
+   * @throws Error if unable to send email
+   */
+  sendCreatorProfileSetupLink(email: string): Promise<void>;
 }
 
 export default ICreatorService;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import Signup from "./components/auth/Signup";
 import SubscriberSignup from "./components/auth/SubscriberSignup";
 import AdminDashboard from "./components/pages/AdminDashboard/AdminDashboard";
 import CreateReviewPage from "./components/pages/CreateReviewPage";
+import FinishProfileLanding from "./components/pages/CreatorProfile/FinishProfileLanding";
 import Default from "./components/pages/Default";
 import DisplayReview from "./components/pages/DisplayReview/DisplayReview";
 import EditReviewPage from "./components/pages/EditReviewPage";
@@ -105,6 +106,12 @@ const App = (): React.ReactElement => {
                       path={Routes.HOME_PAGE}
                       component={MagazineReview}
                       requiredRoles={[UserRole.Admin, UserRole.Subscriber]}
+                    />
+                    <PrivateRoute
+                      exact
+                      path={Routes.CREATOR_PROFILE_LANDING}
+                      component={FinishProfileLanding}
+                      requiredRoles={[UserRole.Admin, UserRole.Creator]}
                     />
                     <PrivateRoute
                       exact

--- a/frontend/src/components/pages/CreatorProfile/FinishProfileLanding.tsx
+++ b/frontend/src/components/pages/CreatorProfile/FinishProfileLanding.tsx
@@ -1,0 +1,58 @@
+import { ArrowForwardIcon } from "@chakra-ui/icons";
+import { Button, Flex, Text } from "@chakra-ui/react";
+import React from "react";
+import { Link } from "react-router-dom";
+
+import background from "../../../assets/NotFoundBack.png";
+import { CREATOR_PROFILE_SETUP } from "../../../constants/Routes";
+
+const FinishProfileLanding = (): React.ReactElement => {
+  return (
+    <Flex
+      direction="column"
+      h="100vh"
+      w="100vw"
+      justify="center"
+      align="center"
+      bgImage={background}
+      bgPosition="center"
+      bgRepeat="no-repeat"
+      backgroundSize="cover"
+      backgroundAttachment="scroll"
+      overflowY="scroll"
+      padding="50px 30px"
+      textAlign="center"
+    >
+      <Text textStyle="heading" fontSize="42px" fontWeight="extrabold">
+        Let&apos;s create your profile!
+      </Text>
+      <Text textStyle="h2" marginY="24px">
+        This is where bookers can get to know you and your work better.
+      </Text>
+
+      <Text
+        textStyle="body"
+        marginTop="10px"
+        marginBottom="102px"
+        zIndex="1"
+        maxWidth="50%"
+      >
+        The following process will take you through the set up for your profile
+        which includes information regarding your basic bio, presentation
+        offerings, some of pieces of your work, and general availability.
+      </Text>
+      <Link to={CREATOR_PROFILE_SETUP}>
+        <Button
+          w="159px"
+          h="48px"
+          leftIcon={<ArrowForwardIcon />}
+          colorScheme="teal"
+        >
+          Get Started
+        </Button>
+      </Link>
+    </Flex>
+  );
+};
+
+export default FinishProfileLanding;

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -8,6 +8,10 @@ export const SIGNUP_PAGE = "/signup";
 
 export const SUBSCRIBER_SIGNUP_PAGE = "/subscriber-signup";
 
+export const CREATOR_PROFILE_LANDING = "/finish-profile";
+
+export const CREATOR_PROFILE_SETUP = "/create-creator-profile";
+
 export const EDIT_TEAM_PAGE = "/edit-team";
 
 export const DISPLAY_ENTITY_PAGE = "/entity";


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Creator “Finish Profile” flow](https://www.notion.so/uwblueprintexecs/Creator-Finish-Profile-flow-736d5955d5e94b31ae491dd65899d8e2)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* added send email function as described in ticket + new page for directing to the create profile flow


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. call verify email route using creator profile (once sign up route completed)
2. visit localhost:3000/finish-profile

![image](https://user-images.githubusercontent.com/75541476/213949196-1ff037f3-32eb-4be5-8002-bd583238e704.png)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
