### PR TITLE
Add Creator Signup

### DIFF
--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -71,7 +71,7 @@ const register = async (
     const { data } = await baseAPIClient.post(
       "/auth/register",
       { firstName, lastName, email },
-      { withCredentials: true},
+      { withCredentials: true },
     );
     return data;
   } catch (error) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 
 /* Pages */
 import AuthActions from "./components/auth/AuthActions";
+import CreatorSignup from "./components/auth/CreatorSignup";
 import ForgotPassword from "./components/auth/ForgotPassword";
 import Login from "./components/auth/Login";
 import PrivateRoute from "./components/auth/routes/PrivateRoute";
@@ -46,9 +47,8 @@ const App = (): React.ReactElement => {
     AUTHENTICATED_USER_KEY,
   );
 
-  const [authenticatedUser, setAuthenticatedUser] = useState<AuthenticatedUser>(
-    currentUser,
-  );
+  const [authenticatedUser, setAuthenticatedUser] =
+    useState<AuthenticatedUser>(currentUser);
 
   // Some sort of global state. Context API replaces redux.
   // Split related states into different contexts as necessary.
@@ -160,6 +160,11 @@ const App = (): React.ReactElement => {
                         UserRole.Subscriber,
                         UserRole.Creator,
                       ]}
+                    />
+                    <Route
+                      exact
+                      path={Routes.CREATOR_SIGNUP_PAGE}
+                      component={CreatorSignup}
                     />
                     <Route
                       exact

--- a/frontend/src/components/auth/CreatorSignup.tsx
+++ b/frontend/src/components/auth/CreatorSignup.tsx
@@ -10,15 +10,13 @@ import {
 import React, { useState } from "react";
 
 import UsersAPIClient from "../../APIClients/UsersAPIClient";
-/* Images */
 import CCBCLogo from "../../images/ccbc-logo.png";
 import LoginGraphic from "../../images/Login-graphic.png";
 import authUtils from "../../utils/AuthUtils";
 import EmailForm from "./EmailForm";
 
-const SubscriberSignup = (): React.ReactElement => {
+const CreatorSignup = (): React.ReactElement => {
   const [isEmailInvalid, setIsEmailInvalid] = useState(false);
-
   const onSendEmailClick = async (email: string) => {
     if (!authUtils.validateEmail(email)) {
       setIsEmailInvalid(true);
@@ -26,7 +24,6 @@ const SubscriberSignup = (): React.ReactElement => {
       await UsersAPIClient.register(email);
     }
   };
-
   return (
     <Grid
       overflow="hidden"
@@ -69,4 +66,4 @@ const SubscriberSignup = (): React.ReactElement => {
   );
 };
 
-export default SubscriberSignup;
+export default CreatorSignup;

--- a/frontend/src/components/auth/CreatorSignup.tsx
+++ b/frontend/src/components/auth/CreatorSignup.tsx
@@ -1,27 +1,40 @@
 import {
   Center,
   FormControl,
+  FormErrorMessage,
   Grid,
   GridItem,
   Image,
   Stack,
   Text,
+  useDisclosure,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 
 import UsersAPIClient from "../../APIClients/UsersAPIClient";
 import CCBCLogo from "../../images/ccbc-logo.png";
 import LoginGraphic from "../../images/Login-graphic.png";
+import { AuthenticatedUser } from "../../types/AuthTypes";
 import authUtils from "../../utils/AuthUtils";
 import EmailForm from "./EmailForm";
+import SuccessfullyCreatedEmailModal from "./SuccessfullyCreatedEmailModal";
 
 const CreatorSignup = (): React.ReactElement => {
   const [isEmailInvalid, setIsEmailInvalid] = useState(false);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
   const onSendEmailClick = async (email: string) => {
     if (!authUtils.validateEmail(email)) {
       setIsEmailInvalid(true);
     } else {
-      await UsersAPIClient.register(email);
+      const user: AuthenticatedUser = await UsersAPIClient.register(email);
+
+      if (user) {
+        setIsEmailInvalid(false);
+        onOpen();
+      } else {
+        setIsEmailInvalid(true);
+      }
     }
   };
   return (
@@ -59,6 +72,8 @@ const CreatorSignup = (): React.ReactElement => {
               isEmailInvalid={isEmailInvalid}
               setIsEmailInvalid={setIsEmailInvalid}
             />
+            <FormErrorMessage>Account creation failed</FormErrorMessage>
+            <SuccessfullyCreatedEmailModal isOpen={isOpen} onClose={onClose} />
           </FormControl>
         </Stack>
       </GridItem>

--- a/frontend/src/components/auth/EmailForm.tsx
+++ b/frontend/src/components/auth/EmailForm.tsx
@@ -1,0 +1,56 @@
+import { Box, Button, FormLabel, Input, Link, Text } from "@chakra-ui/react";
+import React, { useState } from "react";
+
+import { LOGIN_PAGE } from "../../constants/Routes";
+
+type EmailFormProps = {
+  onSendEmailClick: (email: string) => void;
+  isEmailInvalid: boolean;
+  setIsEmailInvalid: (invalid: boolean) => void; // is there react types for useState?
+};
+
+const EmailForm = ({
+  onSendEmailClick,
+  isEmailInvalid,
+  setIsEmailInvalid,
+}: EmailFormProps): React.ReactElement => {
+  const [email, setEmail] = useState("");
+  return (
+    <>
+      <Box mt="4%" mb="4%">
+        <FormLabel>Email address</FormLabel>
+        <Input
+          value={email}
+          name="email"
+          placeholder="example@gmail.com"
+          isInvalid={isEmailInvalid}
+          onChange={(event) => {
+            setEmail(event.target.value);
+            setIsEmailInvalid(false);
+          }}
+        />
+      </Box>
+      <Button
+        variant="submit"
+        type="button"
+        onClick={() => onSendEmailClick(email)}
+      >
+        Sign Up
+      </Button>
+      <Box display="flex" mt="3">
+        <Box mr="1">
+          <Text textStyle="body" color="gray.700">
+            Already have an account?
+          </Text>
+        </Box>
+        <Link href={`${LOGIN_PAGE}`}>
+          <Text fontWeight="bold" color="gray.700" as="u">
+            Log In
+          </Text>
+        </Link>
+      </Box>
+    </>
+  );
+};
+
+export default EmailForm;

--- a/frontend/src/components/auth/EmailForm.tsx
+++ b/frontend/src/components/auth/EmailForm.tsx
@@ -1,4 +1,12 @@
-import { Box, Button, FormLabel, Input, Link, Text } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Link,
+  Text,
+} from "@chakra-ui/react";
 import React, { useState } from "react";
 
 import { LOGIN_PAGE } from "../../constants/Routes";

--- a/frontend/src/components/auth/SubscriberSignup.tsx
+++ b/frontend/src/components/auth/SubscriberSignup.tsx
@@ -2,7 +2,6 @@ import {
   Center,
   FormControl,
   FormErrorMessage,
-  FormLabel,
   Grid,
   GridItem,
   Image,
@@ -24,7 +23,6 @@ import SuccessfullyCreatedEmailModal from "./SuccessfullyCreatedEmailModal";
 const SubscriberSignup = (): React.ReactElement => {
   const [isEmailInvalid, setIsEmailInvalid] = useState(false);
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [email, setEmail] = useState("");
 
   const onSendEmailClick = async (email: string) => {
     if (!authUtils.validateEmail(email)) {
@@ -76,10 +74,8 @@ const SubscriberSignup = (): React.ReactElement => {
               isEmailInvalid={isEmailInvalid}
               setIsEmailInvalid={setIsEmailInvalid}
             />
-          <SuccessfullyCreatedEmailModal
-            isOpen={isOpen}
-            onClose={onClose}
-          />
+            <FormErrorMessage>Account creation failed</FormErrorMessage>
+            <SuccessfullyCreatedEmailModal isOpen={isOpen} onClose={onClose} />
           </FormControl>
         </Stack>
       </GridItem>

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -8,7 +8,7 @@ export const SIGNUP_PAGE = "/signup";
 
 export const SUBSCRIBER_SIGNUP_PAGE = "/subscriber-signup";
 
-export const CREATOR_SIGNUP_PAGE = "/creator-registration";
+export const CREATOR_SIGNUP_PAGE = "/creator-signup";
 
 export const CREATOR_PROFILE_LANDING = "/finish-profile";
 

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -8,6 +8,8 @@ export const SIGNUP_PAGE = "/signup";
 
 export const SUBSCRIBER_SIGNUP_PAGE = "/subscriber-signup";
 
+export const CREATOR_SIGNUP_PAGE = "/creator-registration";
+
 export const EDIT_TEAM_PAGE = "/edit-team";
 
 export const DISPLAY_ENTITY_PAGE = "/entity";


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Creator Signup](https://www.notion.so/uwblueprintexecs/Creator-Signup-e0687bd83429497d9d633a546d10be1b)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Pulled out email form from SubscriberSignup to be a reusable component
* -Created new CreatorSignup component
* Added 'creator-registration' route to the CreatorSignup component

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to localhost:3000/creator-registration
2. Input email and press the sign up button
3. There is no success feedback for a successful response, heck your email to ensure a link has been sent

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* frontend/src/components/auth/EmailForm.tsx: 9. Is there a better way to do the type interface for a useHook function? As well is there a way that we do not need to pass in the isEmailInvalid, and setIsEmailInvalid into the EmailForm component?
* The CreatorSignup component currently uses the exact Subscriber signup logic, is this sufficient for this ticket?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
