### PR TITLE
[Feat]: Add creator info form setup + contact info form

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import Signup from "./components/auth/Signup";
 import SubscriberSignup from "./components/auth/SubscriberSignup";
 import AdminDashboard from "./components/pages/AdminDashboard/AdminDashboard";
 import CreateReviewPage from "./components/pages/CreateReviewPage";
+import CreatorProfileForm from "./components/pages/CreatorProfile/CreatorProfileForm";
 import FinishProfileLanding from "./components/pages/CreatorProfile/FinishProfileLanding";
 import Default from "./components/pages/Default";
 import DisplayReview from "./components/pages/DisplayReview/DisplayReview";
@@ -111,6 +112,12 @@ const App = (): React.ReactElement => {
                       exact
                       path={Routes.CREATOR_PROFILE_LANDING}
                       component={FinishProfileLanding}
+                      requiredRoles={[UserRole.Admin, UserRole.Creator]}
+                    />
+                    <PrivateRoute
+                      exact
+                      path={Routes.CREATOR_PROFILE_SETUP}
+                      component={CreatorProfileForm}
                       requiredRoles={[UserRole.Admin, UserRole.Creator]}
                     />
                     <PrivateRoute

--- a/frontend/src/components/pages/CreatorProfile/ContactInfoForm.tsx
+++ b/frontend/src/components/pages/CreatorProfile/ContactInfoForm.tsx
@@ -1,0 +1,144 @@
+import {
+  Center,
+  Flex,
+  FormControl,
+  FormLabel,
+  Input,
+  Spacer,
+  Text,
+} from "@chakra-ui/react";
+import React from "react";
+
+import CreatorInputField from "./CreatorInputField";
+
+interface ContactInfoProps {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  address: string;
+  city: string;
+  province: string;
+  postalCode: string;
+  setFirstName: React.Dispatch<React.SetStateAction<string>>;
+  setLastName: React.Dispatch<React.SetStateAction<string>>;
+  setEmail: React.Dispatch<React.SetStateAction<string>>;
+  setPhone: React.Dispatch<React.SetStateAction<string>>;
+  setAddress: React.Dispatch<React.SetStateAction<string>>;
+  setCity: React.Dispatch<React.SetStateAction<string>>;
+  setProvince: React.Dispatch<React.SetStateAction<string>>;
+  setPostalCode: React.Dispatch<React.SetStateAction<string>>;
+  submitted: boolean;
+}
+
+const ContactInfoForm = ({
+  firstName,
+  lastName,
+  email,
+  phone,
+  address,
+  city,
+  province,
+  postalCode,
+  setFirstName,
+  setLastName,
+  setEmail,
+  setPhone,
+  setAddress,
+  setCity,
+  setProvince,
+  setPostalCode,
+  submitted,
+}: ContactInfoProps): React.ReactElement => {
+  return (
+    <Flex flex="1" direction="column" justify="start">
+      <Text textStyle="heading" textAlign="left" fontWeight="bold">
+        Contact Info
+      </Text>
+      <Text textAlign="left" mb="5">
+        This info is for CCBC record keeping purposes and will not be displayed
+        on your profile.
+      </Text>
+      <div>
+        <CreatorInputField
+          name="First name"
+          value={firstName}
+          setter={setFirstName}
+          error={submitted}
+          width="33%"
+        />
+        <CreatorInputField
+          name="Last name"
+          value={lastName}
+          setter={setLastName}
+          error={submitted}
+          width="33%"
+        />
+        <CreatorInputField
+          name="Email address"
+          placeholder="ex. johndoe@gmail.com"
+          value={email}
+          setter={setEmail}
+          error={submitted}
+          width="50%"
+        />
+        <CreatorInputField
+          name="Phone number"
+          placeholder="ex. (123)456-7890"
+          value={phone}
+          setter={setPhone}
+          error={submitted}
+          width="25%"
+        />
+        <CreatorInputField
+          name="Street Address"
+          placeholder="ex. 121 Alphabet Street"
+          value={address}
+          setter={setAddress}
+          error={submitted}
+        />
+
+        <Flex gap="3">
+          <CreatorInputField
+            name="City"
+            value={city}
+            setter={setCity}
+            error={submitted}
+          />
+          <Flex w="10" />
+          <CreatorInputField
+            name="Province"
+            value={province}
+            selectOptions={[
+              "Alberta",
+              "British Columbia",
+              "Manitoba",
+              "New Brunswick",
+              "Newfoundland and Labrador",
+              "Northwest Territories",
+              "Nova Scotia",
+              "Nunavut",
+              "Ontario",
+              "Prince Edward Island",
+              "Quebec",
+              "Saskatchewan",
+              "Yukon Territory",
+            ]}
+            setter={setProvince}
+            error={submitted}
+          />
+          <Flex w="10" />
+          <CreatorInputField
+            name="Postal code"
+            placeholder="ex. A1B 2C3"
+            value={postalCode}
+            setter={setPostalCode}
+            error={submitted}
+          />
+        </Flex>
+      </div>
+    </Flex>
+  );
+};
+
+export default ContactInfoForm;

--- a/frontend/src/components/pages/CreatorProfile/CreatorInputField.tsx
+++ b/frontend/src/components/pages/CreatorProfile/CreatorInputField.tsx
@@ -1,0 +1,68 @@
+import {
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Select,
+} from "@chakra-ui/react";
+import React from "react";
+
+interface CreatorInputFieldProps {
+  name: string;
+  value: string;
+  setter: React.Dispatch<React.SetStateAction<string>>;
+  placeholder?: string;
+  error?: boolean;
+  selectOptions?: Array<string>;
+  width?: string;
+}
+
+const CreatorInputField = ({
+  name,
+  placeholder,
+  error = false,
+  selectOptions,
+  width = "full",
+  value,
+  setter,
+}: CreatorInputFieldProps): React.ReactElement => {
+  const handleOnChange = (
+    func: React.Dispatch<React.SetStateAction<string>>,
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
+    func(e.target.value);
+  };
+
+  return (
+    <FormControl isRequired isInvalid={error && value === ""}>
+      <FormLabel mb="1" mt="3">
+        {name}
+      </FormLabel>
+      {selectOptions ? (
+        <Select
+          placeholder={placeholder || `Enter your ${name.toLowerCase()}`}
+          value={value}
+          onChange={(e) => handleOnChange(setter, e)}
+        >
+          {selectOptions.map((item, index) => {
+            return <option key={index}>{item}</option>;
+          })}
+        </Select>
+      ) : (
+        <Input
+          placeholder={placeholder || `Enter your ${name.toLowerCase()}`}
+          value={value}
+          onChange={(e) => handleOnChange(setter, e)}
+          width={width}
+        />
+      )}
+      {error && value === "" && (
+        <FormErrorMessage>
+          Please enter you {name.toLowerCase()}
+        </FormErrorMessage>
+      )}
+    </FormControl>
+  );
+};
+
+export default CreatorInputField;

--- a/frontend/src/components/pages/CreatorProfile/CreatorProfileForm.tsx
+++ b/frontend/src/components/pages/CreatorProfile/CreatorProfileForm.tsx
@@ -1,0 +1,205 @@
+import { ArrowBackIcon, ArrowForwardIcon } from "@chakra-ui/icons";
+import {
+  Button,
+  Center,
+  createIcon,
+  Flex,
+  Spacer,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
+} from "@chakra-ui/react";
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+
+import { CREATOR_PROFILE_LANDING } from "../../../constants/Routes";
+import ContactInfoForm from "./ContactInfoForm";
+
+const SaveIcon = createIcon({
+  displayName: "SaveIcon",
+  viewBox: "0 0 14 15",
+  path: (
+    <path
+      d="M2.47656 5.49518V5.51861H2.5H8.5H8.52343V5.49518V3.49518V3.47174H8.5H2.5H2.47656V3.49518V5.49518ZM9.5206 11.1138L9.5206 11.1137C9.53608 10.763 9.47842 10.413 9.35129 10.0858C9.22416 9.75862 9.03034 9.46147 8.78215 9.21325C8.53396 8.96503 8.23684 8.77117 7.90967 8.644C7.5825 8.51683 7.23245 8.45913 6.88178 8.47457L6.88171 8.47458C6.39324 8.49749 5.92195 8.66183 5.52515 8.94763C5.12835 9.23342 4.82314 9.62835 4.64663 10.0844C4.47012 10.5404 4.42992 11.0379 4.53091 11.5164C4.6319 11.9949 4.86974 12.4337 5.2155 12.7795C5.56126 13.1253 6.00004 13.3632 6.4785 13.4642C6.95695 13.5653 7.45445 13.5251 7.91051 13.3487C8.36658 13.1722 8.76154 12.867 9.04738 12.4703C9.33322 12.0735 9.49763 11.6022 9.5206 11.1138ZM1 1.01862H10.879L13.9766 4.11614V13.9951C13.9758 14.2539 13.8727 14.5019 13.6897 14.6849C13.5067 14.8679 13.2587 14.971 12.9999 14.9717H1C0.740999 14.9717 0.492607 14.8688 0.309466 14.6857C0.126325 14.5026 0.0234375 14.2542 0.0234375 13.9952V1.99518C0.0234375 1.73618 0.126325 1.48779 0.309466 1.30464C0.492607 1.1215 0.740999 1.01862 1 1.01862Z"
+      fill="#0EBCBD"
+      stroke="#0EBCBD"
+      strokeWidth="0.046875"
+    />
+  ),
+});
+
+const CreatorProfileForm = (): React.ReactElement => {
+  // Contact Info Form
+  const [firstName, setFirstName] = useState<string>("");
+  const [lastName, setLastName] = useState<string>("");
+  const [email, setEmail] = useState<string>("");
+  const [phone, setPhone] = useState<string>("");
+  const [address, setAddress] = useState<string>("");
+  const [city, setCity] = useState<string>("");
+  const [province, setProvince] = useState<string>("");
+  const [postalCode, setPostalCode] = useState<string>("");
+
+  const [activeForm, setActiveForm] = useState<number>(0);
+  const [error, setError] = useState<boolean>(false);
+
+  const forms = [
+    "Contact Info",
+    "General",
+    "Presentations",
+    "Publications",
+    "Availability",
+    "Review",
+  ];
+
+  const handleNav = (direction: number) => {
+    if (
+      activeForm === 0 &&
+      (firstName === "" ||
+        lastName === "" ||
+        email === "" ||
+        phone === "" ||
+        address === "" ||
+        city === "" ||
+        province === "" ||
+        postalCode === "")
+    ) {
+      setError(true);
+      return;
+    }
+    setError(false);
+    if (direction === 1) {
+      setActiveForm(Math.min(activeForm + 1, 5));
+    } else {
+      setActiveForm(Math.max(activeForm - 1, 0));
+    }
+  };
+
+  return (
+    <>
+      <Link to={CREATOR_PROFILE_LANDING}>
+        <Button
+          textAlign="left"
+          leftIcon={<ArrowBackIcon />}
+          mt="5"
+          ml="5"
+          variant="link"
+          color="black"
+        >
+          Back
+        </Button>
+      </Link>
+      <Flex
+        direction={{ sm: "column", base: "row", md: "row", lg: "row" }}
+        justify="center"
+      >
+        <Flex
+          direction="column"
+          justify="start"
+          align="start"
+          pr="16"
+          pl="8"
+          pt="4"
+        >
+          {forms.map((form, index) => {
+            return (
+              <Flex key={index}>
+                <Flex direction="column" align="center">
+                  <Center
+                    border="2px"
+                    borderColor={activeForm === index ? "teal.300" : "gray.300"}
+                    rounded="full"
+                    height="10"
+                    width="10"
+                    padding="3"
+                  >
+                    <Text
+                      fontSize="18"
+                      fontWeight="medium"
+                      color={activeForm === index ? "teal.300" : "gray.300"}
+                    >
+                      {index + 1}
+                    </Text>
+                  </Center>
+                  {index !== 5 && (
+                    <Center
+                      borderLeftColor="gray.300"
+                      height="10"
+                      style={{ borderLeftWidth: 2 }}
+                    />
+                  )}
+                </Flex>
+                <Text
+                  fontSize="18"
+                  color={activeForm === index ? "teal.300" : "gray.300"}
+                  ps="2"
+                  pt="1.5"
+                  fontWeight="medium"
+                >
+                  {form}
+                </Text>
+              </Flex>
+            );
+          })}
+        </Flex>
+        <Flex direction="column" pt="4">
+          <Center borderLeftWidth="thin" borderLeftColor="gray.200" px="16">
+            {activeForm === 0 && (
+              <ContactInfoForm
+                firstName={firstName}
+                lastName={lastName}
+                email={email}
+                phone={phone}
+                address={address}
+                city={city}
+                province={province}
+                postalCode={postalCode}
+                setFirstName={setFirstName}
+                setLastName={setLastName}
+                setEmail={setEmail}
+                setPhone={setPhone}
+                setAddress={setAddress}
+                setCity={setCity}
+                setProvince={setProvince}
+                setPostalCode={setPostalCode}
+                submitted={error}
+              />
+            )}
+          </Center>
+          <Flex justify="space-between" my="20" px="16">
+            <Button
+              leftIcon={<ArrowBackIcon />}
+              colorScheme="teal"
+              disabled={activeForm === 0}
+              onClick={() => handleNav(-1)}
+            >
+              Previous
+            </Button>
+            <Flex>
+              <Button
+                colorScheme="teal"
+                variant="outline"
+                leftIcon={<SaveIcon />}
+              >
+                Save and exit
+              </Button>
+              <Spacer w="3" />
+              <Button
+                leftIcon={<ArrowForwardIcon />}
+                colorScheme="teal"
+                disabled={activeForm === 5}
+                onClick={() => handleNav(1)}
+              >
+                Next
+              </Button>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+    </>
+  );
+};
+
+export default CreatorProfileForm;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Creator Profile: Setup + Contact Info Form](https://www.notion.so/uwblueprintexecs/Creator-Profile-Setup-Contact-Info-Form-4dbbb2da01234060ae7bcf5ea1b8d6ef)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* As mentioned in ticket, added a new CreatorProfileForm component and set up a 'Tab' system to navigate between each stage of form
* Added first form, contact info that stores all info into state in the original creator profile form

![image](https://user-images.githubusercontent.com/75541476/214749104-95cd89f7-0fd7-47c9-a7a5-fe5cb2d6f9dc.png)
![image](https://user-images.githubusercontent.com/75541476/214749170-62554347-1d38-418c-bc9c-e9eec07c62f3.png)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Visit `create-creator-profile` page and navigate to other tab



## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
