### PR TITLE
[Refactor]: Swap useState for useContext for creator profile form

### DIFF
--- a/frontend/src/components/pages/CreatorProfile/ContactInfoForm.tsx
+++ b/frontend/src/components/pages/CreatorProfile/ContactInfoForm.tsx
@@ -1,55 +1,18 @@
-import {
-  Center,
-  Flex,
-  FormControl,
-  FormLabel,
-  Input,
-  Spacer,
-  Text,
-} from "@chakra-ui/react";
-import React from "react";
+import { Flex, Text } from "@chakra-ui/react";
+import React, { useContext } from "react";
 
+import CreatorProfileContext from "../../../contexts/CreatorProfileContext";
 import CreatorInputField from "./CreatorInputField";
 
 interface ContactInfoProps {
-  firstName: string;
-  lastName: string;
-  email: string;
-  phone: string;
-  address: string;
-  city: string;
-  province: string;
-  postalCode: string;
-  setFirstName: React.Dispatch<React.SetStateAction<string>>;
-  setLastName: React.Dispatch<React.SetStateAction<string>>;
-  setEmail: React.Dispatch<React.SetStateAction<string>>;
-  setPhone: React.Dispatch<React.SetStateAction<string>>;
-  setAddress: React.Dispatch<React.SetStateAction<string>>;
-  setCity: React.Dispatch<React.SetStateAction<string>>;
-  setProvince: React.Dispatch<React.SetStateAction<string>>;
-  setPostalCode: React.Dispatch<React.SetStateAction<string>>;
   submitted: boolean;
 }
 
 const ContactInfoForm = ({
-  firstName,
-  lastName,
-  email,
-  phone,
-  address,
-  city,
-  province,
-  postalCode,
-  setFirstName,
-  setLastName,
-  setEmail,
-  setPhone,
-  setAddress,
-  setCity,
-  setProvince,
-  setPostalCode,
   submitted,
 }: ContactInfoProps): React.ReactElement => {
+  const { creatorProfile } = useContext(CreatorProfileContext);
+
   return (
     <Flex flex="1" direction="column" justify="start">
       <Text textStyle="heading" textAlign="left" fontWeight="bold">
@@ -62,53 +25,53 @@ const ContactInfoForm = ({
       <div>
         <CreatorInputField
           name="First name"
-          value={firstName}
-          setter={setFirstName}
+          value={creatorProfile?.firstName}
+          field="firstName"
           error={submitted}
           width="33%"
         />
         <CreatorInputField
           name="Last name"
-          value={lastName}
-          setter={setLastName}
+          value={creatorProfile?.lastName}
+          field="lastName"
           error={submitted}
           width="33%"
         />
         <CreatorInputField
           name="Email address"
           placeholder="ex. johndoe@gmail.com"
-          value={email}
-          setter={setEmail}
+          value={creatorProfile?.email}
+          field="email"
           error={submitted}
           width="50%"
         />
         <CreatorInputField
           name="Phone number"
           placeholder="ex. (123)456-7890"
-          value={phone}
-          setter={setPhone}
+          value={creatorProfile?.phone}
+          field="phone"
           error={submitted}
           width="25%"
         />
         <CreatorInputField
           name="Street Address"
           placeholder="ex. 121 Alphabet Street"
-          value={address}
-          setter={setAddress}
+          value={creatorProfile?.address}
+          field="address"
           error={submitted}
         />
 
         <Flex gap="3">
           <CreatorInputField
             name="City"
-            value={city}
-            setter={setCity}
+            value={creatorProfile?.city}
+            field="city"
             error={submitted}
           />
           <Flex w="10" />
           <CreatorInputField
             name="Province"
-            value={province}
+            value={creatorProfile?.province}
             selectOptions={[
               "Alberta",
               "British Columbia",
@@ -124,15 +87,15 @@ const ContactInfoForm = ({
               "Saskatchewan",
               "Yukon Territory",
             ]}
-            setter={setProvince}
+            field="province"
             error={submitted}
           />
           <Flex w="10" />
           <CreatorInputField
             name="Postal code"
             placeholder="ex. A1B 2C3"
-            value={postalCode}
-            setter={setPostalCode}
+            value={creatorProfile?.postalCode}
+            field="postalCode"
             error={submitted}
           />
         </Flex>

--- a/frontend/src/components/pages/CreatorProfile/CreatorInputField.tsx
+++ b/frontend/src/components/pages/CreatorProfile/CreatorInputField.tsx
@@ -5,12 +5,18 @@ import {
   Input,
   Select,
 } from "@chakra-ui/react";
-import React from "react";
+import React, { useContext } from "react";
+
+import CreatorProfileContext from "../../../contexts/CreatorProfileContext";
+import {
+  CreatorProfile,
+  CreatorProfileProps,
+} from "../../../types/CreatorProfileTypes";
 
 interface CreatorInputFieldProps {
   name: string;
-  value: string;
-  setter: React.Dispatch<React.SetStateAction<string>>;
+  value?: string;
+  field: CreatorProfileProps;
   placeholder?: string;
   error?: boolean;
   selectOptions?: Array<string>;
@@ -24,13 +30,20 @@ const CreatorInputField = ({
   selectOptions,
   width = "full",
   value,
-  setter,
+  field,
 }: CreatorInputFieldProps): React.ReactElement => {
+  const { creatorProfile, setCreatorProfile } = useContext(
+    CreatorProfileContext,
+  );
+
   const handleOnChange = (
-    func: React.Dispatch<React.SetStateAction<string>>,
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
   ) => {
-    func(e.target.value);
+    const creatorProfileObj: CreatorProfile = {
+      ...creatorProfile,
+    };
+    creatorProfileObj[field] = e.target.value;
+    setCreatorProfile(creatorProfileObj);
   };
 
   return (
@@ -42,7 +55,7 @@ const CreatorInputField = ({
         <Select
           placeholder={placeholder || `Enter your ${name.toLowerCase()}`}
           value={value}
-          onChange={(e) => handleOnChange(setter, e)}
+          onChange={(e) => handleOnChange(e)}
         >
           {selectOptions.map((item, index) => {
             return <option key={index}>{item}</option>;
@@ -52,7 +65,7 @@ const CreatorInputField = ({
         <Input
           placeholder={placeholder || `Enter your ${name.toLowerCase()}`}
           value={value}
-          onChange={(e) => handleOnChange(setter, e)}
+          onChange={(e) => handleOnChange(e)}
           width={width}
         />
       )}

--- a/frontend/src/components/pages/CreatorProfile/CreatorProfileForm.tsx
+++ b/frontend/src/components/pages/CreatorProfile/CreatorProfileForm.tsx
@@ -5,17 +5,14 @@ import {
   createIcon,
   Flex,
   Spacer,
-  Tab,
-  TabList,
-  TabPanel,
-  TabPanels,
-  Tabs,
   Text,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 
 import { CREATOR_PROFILE_LANDING } from "../../../constants/Routes";
+import CreatorProfileContext from "../../../contexts/CreatorProfileContext";
+import { CreatorProfile } from "../../../types/CreatorProfileTypes";
 import ContactInfoForm from "./ContactInfoForm";
 
 const SaveIcon = createIcon({
@@ -32,15 +29,16 @@ const SaveIcon = createIcon({
 });
 
 const CreatorProfileForm = (): React.ReactElement => {
-  // Contact Info Form
-  const [firstName, setFirstName] = useState<string>("");
-  const [lastName, setLastName] = useState<string>("");
-  const [email, setEmail] = useState<string>("");
-  const [phone, setPhone] = useState<string>("");
-  const [address, setAddress] = useState<string>("");
-  const [city, setCity] = useState<string>("");
-  const [province, setProvince] = useState<string>("");
-  const [postalCode, setPostalCode] = useState<string>("");
+  const [creatorProfile, setCreatorProfile] = useState<CreatorProfile>({
+    firstName: "",
+    lastName: "",
+    email: "",
+    phone: "",
+    address: "",
+    city: "",
+    province: "",
+    postalCode: "",
+  });
 
   const [activeForm, setActiveForm] = useState<number>(0);
   const [error, setError] = useState<boolean>(false);
@@ -57,14 +55,14 @@ const CreatorProfileForm = (): React.ReactElement => {
   const handleNav = (direction: number) => {
     if (
       activeForm === 0 &&
-      (firstName === "" ||
-        lastName === "" ||
-        email === "" ||
-        phone === "" ||
-        address === "" ||
-        city === "" ||
-        province === "" ||
-        postalCode === "")
+      (creatorProfile?.firstName === "" ||
+        creatorProfile?.lastName === "" ||
+        creatorProfile?.email === "" ||
+        creatorProfile?.phone === "" ||
+        creatorProfile?.address === "" ||
+        creatorProfile?.city === "" ||
+        creatorProfile?.province === "" ||
+        creatorProfile?.postalCode === "")
     ) {
       setError(true);
       return;
@@ -146,27 +144,11 @@ const CreatorProfileForm = (): React.ReactElement => {
         </Flex>
         <Flex direction="column" pt="4">
           <Center borderLeftWidth="thin" borderLeftColor="gray.200" px="16">
-            {activeForm === 0 && (
-              <ContactInfoForm
-                firstName={firstName}
-                lastName={lastName}
-                email={email}
-                phone={phone}
-                address={address}
-                city={city}
-                province={province}
-                postalCode={postalCode}
-                setFirstName={setFirstName}
-                setLastName={setLastName}
-                setEmail={setEmail}
-                setPhone={setPhone}
-                setAddress={setAddress}
-                setCity={setCity}
-                setProvince={setProvince}
-                setPostalCode={setPostalCode}
-                submitted={error}
-              />
-            )}
+            <CreatorProfileContext.Provider
+              value={{ creatorProfile, setCreatorProfile }}
+            >
+              {activeForm === 0 && <ContactInfoForm submitted={error} />}
+            </CreatorProfileContext.Provider>
           </Center>
           <Flex justify="space-between" my="20" px="16">
             <Button

--- a/frontend/src/contexts/CreatorProfileContext.ts
+++ b/frontend/src/contexts/CreatorProfileContext.ts
@@ -1,0 +1,15 @@
+import React, { createContext } from "react";
+
+import { CreatorProfile } from "../types/CreatorProfileTypes";
+
+type CreatorProfileContextType = {
+  creatorProfile: CreatorProfile;
+  setCreatorProfile: React.Dispatch<React.SetStateAction<CreatorProfile>>;
+};
+
+const CreatorProfileContext = createContext<CreatorProfileContextType>({
+  creatorProfile: null,
+  setCreatorProfile: () => {},
+});
+
+export default CreatorProfileContext;

--- a/frontend/src/types/CreatorProfileTypes.ts
+++ b/frontend/src/types/CreatorProfileTypes.ts
@@ -1,0 +1,20 @@
+export type CreatorProfile = {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  address?: string;
+  city?: string;
+  province?: string;
+  postalCode?: string;
+} | null;
+
+export type CreatorProfileProps =
+  | "firstName"
+  | "lastName"
+  | "email"
+  | "phone"
+  | "address"
+  | "city"
+  | "province"
+  | "postalCode";


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Creator Profile: Setup + Contact Info Form](https://www.notion.so/uwblueprintexecs/Creator-Profile-Setup-Contact-Info-Form-4dbbb2da01234060ae7bcf5ea1b8d6ef)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Follow up from previous to refactor instead of passing several state variables, instead using a creatorProfileContext for the creator object throughout the form pages 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
