### PR TITLE
refactor audience review filter

### DIFF
--- a/frontend/src/components/pages/SearchReviews/SearchReviews.tsx
+++ b/frontend/src/components/pages/SearchReviews/SearchReviews.tsx
@@ -58,24 +58,12 @@ const SearchReviews = (): React.ReactElement => {
       },
     );
 
-    const ageArr = [];
-    // eslint-disable-next-line no-restricted-syntax, guard-for-in
-    for (const review in displayedReviews) {
-      const targetBook = displayedReviews[review].books[0];
-      const ageRange = `${targetBook.minAge},${targetBook.maxAge}`;
-      const ageOpt = {
-        label: `Ages ${ageRange.replace(",", "-")}`,
+    const ageArr = ["0-3", "4-8", "9-12", "12-18"].map((ageRange) => {
+      return {
+        label: `Ages ${ageRange}`,
         value: ageRange,
       };
-
-      if (
-        ageArr.findIndex(
-          (opt) => opt.label === ageOpt.label && opt.value === ageOpt.value,
-        ) === -1
-      ) {
-        ageArr.push(ageOpt);
-      }
-    }
+    });
     setAllAges(ageArr);
   }, []);
 
@@ -124,29 +112,6 @@ const SearchReviews = (): React.ReactElement => {
       .then((reviewResponse: PaginatedReviewResponse) => {
         settotalReviews(reviewResponse.totalReviews);
         setDisplayedReviews(mapReviewResponseToReview(reviewResponse.reviews));
-        const ageArr = [];
-        // eslint-disable-next-line no-restricted-syntax, guard-for-in
-        for (const review in mapReviewResponseToReview(
-          reviewResponse.reviews,
-        )) {
-          const targetBook = mapReviewResponseToReview(reviewResponse.reviews)[
-            review
-          ].books[0];
-          const ageRange = `${targetBook.minAge}-${targetBook.maxAge}`;
-          const ageOpt = {
-            label: `Ages ${ageRange}`,
-            value: ageRange,
-          };
-
-          if (
-            ageArr.findIndex(
-              (opt) => opt.label === ageOpt.label && opt.value === ageOpt.value,
-            ) === -1
-          ) {
-            ageArr.push(ageOpt);
-          }
-        }
-        setAllAges(ageArr);
         setLoading(false);
       });
   }, [searchText, genresFilter, ageRangeFilter]);
@@ -177,7 +142,6 @@ const SearchReviews = (): React.ReactElement => {
                 setAgeRangeFilter([Math.min(...ageOpts), Math.max(...ageOpts)]);
               }}
             />
-            {console.log(allAges)}
           </Box>
           <VStack spacing="24px" align="stretch">
             {searchText !== "" && !loading && totalReviews === 1 && (


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Audience Filter](https://www.notion.so/uwblueprintexecs/Audience-Filter-a372c5269ee64535b2c8a956411d9715?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Update logic to use hardcoded options for the audience age ranges instead of the reviews that are shown


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Proceed to Magazine Directory > Search and test filters - with seed data age 0-3 should show no results and all other filters should show all reviews (query also shown in url)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Want to confirm filtering requirements - does 3-17 mean it should be included in the 0-3 section?
* Are those the required age ranges? `["0-3", "4-8", "9-12", "12-18"]`


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
