### PR TITLE
Add CreatorInquiry form modal to CreatorProfile 

### DIFF
--- a/backend/typescript/rest/creatorBookingRoutes.ts
+++ b/backend/typescript/rest/creatorBookingRoutes.ts
@@ -11,13 +11,12 @@ const creatorBookingRouter: Router = Router();
 const creatorBookingService: ICreatorBookingService =
   new CreatorBookingService();
 
-
 creatorBookingRouter.post("/:id", async (req, res) => {
   const contentType = req.headers["content-type"];
   try {
     const { id } = req.params;
     const newBooking = await creatorBookingService.addCreatorBooking({
-      creatorId: parseInt(id),
+      creatorId: parseInt(id, 10),
       name: req.body.name,
       email: req.body.email,
       date: req.body.date,

--- a/backend/typescript/rest/creatorBookingRoutes.ts
+++ b/backend/typescript/rest/creatorBookingRoutes.ts
@@ -11,11 +11,13 @@ const creatorBookingRouter: Router = Router();
 const creatorBookingService: ICreatorBookingService =
   new CreatorBookingService();
 
-creatorBookingRouter.post("/", async (req, res) => {
+
+creatorBookingRouter.post("/:id", async (req, res) => {
   const contentType = req.headers["content-type"];
   try {
+    const { id } = req.params;
     const newBooking = await creatorBookingService.addCreatorBooking({
-      creatorId: req.body.creatorId,
+      creatorId: parseInt(id),
       name: req.body.name,
       email: req.body.email,
       date: req.body.date,

--- a/frontend/src/APIClients/CreatorAPIClient.ts
+++ b/frontend/src/APIClients/CreatorAPIClient.ts
@@ -1,4 +1,4 @@
-import { Creator } from "../types/CreatorTypes";
+import { Creator, CreatorBookingRequest } from "../types/CreatorTypes";
 import { getBearerToken } from "../utils/AuthUtils";
 import baseAPIClient from "./BaseAPIClient";
 
@@ -110,6 +110,25 @@ const updateCreator = async (
   }
 };
 
+const addCreatorBooking = async (
+  creatorBooking: CreatorBookingRequest,
+): Promise<void> => {
+  try {
+    await baseAPIClient.post(
+      `/booking/${creatorBooking.creatorId}`,
+      creatorBooking,
+      {
+        headers: {
+          Authorization: getBearerToken(),
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  } catch (error) {
+    throw new Error("Add creator booking request failed");
+  }
+};
+
 /**
  * This function obtains a creator given a unique identifer
  *
@@ -132,5 +151,6 @@ export default {
   deleteCreator,
   createCreator,
   updateCreator,
+  addCreatorBooking,
   getCreatorById,
 };

--- a/frontend/src/components/pages/CreatorProfile/ContactInquiry.tsx
+++ b/frontend/src/components/pages/CreatorProfile/ContactInquiry.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   CloseButton,
   Divider,
+  Flex,
   HStack,
   Icon,
   Image,
@@ -22,14 +23,20 @@ import {
 import React, { useState } from "react";
 import { HiLightBulb } from "react-icons/hi2";
 
+import { Creator } from "../../../types/CreatorTypes";
+
 const MDYFormat = "MM/DD/YYYY";
 
 export type ContactInquiryProps = {
-  creatorID: number;
+  currentCreator: Creator;
+  isOpen: boolean;
+  onClose: () => void;
 };
 
 const ContactInquiry = ({
-  creatorID: number,
+  currentCreator,
+  isOpen,
+  onClose,
 }: ContactInquiryProps): React.ReactElement => {
   const [messageLength, setMessageLength] = useState<number>(0);
   const [externalBooking, setExternalBooking] = useState<boolean>(false);
@@ -38,8 +45,6 @@ const ContactInquiry = ({
   const [date2, setDate2] = useState<string>(MDYFormat);
   const [formView, setFormView] = useState<boolean>(true);
   const [exitCaution, setExitCaution] = useState<boolean>(false);
-
-  const onClose = () => {};
 
   const ageGroups = [
     "Pre-k",
@@ -52,7 +57,7 @@ const ContactInquiry = ({
   ];
 
   return (
-    <Modal isOpen onClose={onClose} isCentered>
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
       <ModalOverlay />
       <ModalContent
         minW="1181px"
@@ -92,10 +97,17 @@ const ContactInquiry = ({
                         py="11px"
                         pl="15px"
                       >
-                        <Text fontSize="18px" fontWeight={500}>
-                          [pfp] James Martin
-                          {/* TODO: add profile pic and replace placeholder name */}
-                        </Text>
+                        <Flex alignItems="center" justifyContent="center">
+                          <Image
+                            src={currentCreator.profilePictureLink}
+                            boxSize="38px"
+                            borderRadius="100px"
+                            mr="10px"
+                          />
+                          <Text fontSize="18px" fontWeight={700}>
+                            {`${currentCreator.firstName} ${currentCreator.lastName}`}
+                          </Text>
+                        </Flex>
                         <Divider
                           orientation="vertical"
                           height="18px"
@@ -103,7 +115,7 @@ const ContactInquiry = ({
                           borderColor="#A0AEC0"
                         />
                         <Text fontSize="16px" fontWeight={400}>
-                          Illustrator{/* TODO: replace placeholder role */}
+                          {currentCreator.craft}
                         </Text>
                       </HStack>
                     </Box>
@@ -375,6 +387,7 @@ const ContactInquiry = ({
                     alignSelf="flex-end"
                     onClick={() => {
                       setFormView(false);
+                      // TODO: Send ContactInquiry form data.
                     }}
                   >
                     Submit
@@ -437,6 +450,7 @@ const ContactInquiry = ({
                 mr="16px"
                 onClick={() => {
                   onClose();
+                  setExitCaution(false);
                 }}
               >
                 Yes, exit

--- a/frontend/src/components/pages/CreatorProfile/ContactInquiry.tsx
+++ b/frontend/src/components/pages/CreatorProfile/ContactInquiry.tsx
@@ -23,7 +23,8 @@ import {
 import React, { useState } from "react";
 import { HiLightBulb } from "react-icons/hi2";
 
-import { Creator } from "../../../types/CreatorTypes";
+import creatorAPIClient from "../../../APIClients/CreatorAPIClient";
+import { Creator, CreatorBookingRequest } from "../../../types/CreatorTypes";
 
 const MDYFormat = "MM/DD/YYYY";
 
@@ -38,13 +39,19 @@ const ContactInquiry = ({
   isOpen,
   onClose,
 }: ContactInquiryProps): React.ReactElement => {
-  const [messageLength, setMessageLength] = useState<number>(0);
   const [externalBooking, setExternalBooking] = useState<boolean>(false);
   const [tentativeDate, setTentativeDate] = useState<boolean>(true);
-  const [date1, setDate1] = useState<string>(MDYFormat);
-  const [date2, setDate2] = useState<string>(MDYFormat);
+  const [preferredDate, setPreferredDate] = useState<boolean>(false);
+  const [date1, setDate1] = useState<string>("");
+  const [date2, setDate2] = useState<string>("");
   const [formView, setFormView] = useState<boolean>(true);
   const [exitCaution, setExitCaution] = useState<boolean>(false);
+  const [ageGroup, setAgeGroup] = useState<string>("");
+  const [audienceSize, setAudienceSize] = useState<number>(0);
+  const [subject, setSubject] = useState<string>("");
+  const [message, setMessage] = useState<string>("");
+  const [replyEmail, setReplyEmail] = useState<string>("");
+  const [contactName, setContactName] = useState<string>("");
 
   const ageGroups = [
     "Pre-k",
@@ -55,6 +62,32 @@ const ContactInquiry = ({
     "Grades 7-8",
     "Grades 9-12",
   ];
+
+  const submitCreatorBooking = async () => {
+    let date;
+
+    if (preferredDate || !date2) {
+      date = date1;
+    } else {
+      date = `${date1} - ${date2}`;
+    }
+
+    const creatorBookingRequest: CreatorBookingRequest = {
+      creatorId: currentCreator.id,
+      name: contactName,
+      email: replyEmail,
+      date,
+      isTentative: tentativeDate,
+      isOneDay: preferredDate,
+      ageGroup,
+      audienceSize,
+      subject,
+      message,
+    };
+
+    await creatorAPIClient.addCreatorBooking(creatorBookingRequest);
+    setFormView(false);
+  };
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} isCentered>
@@ -145,6 +178,9 @@ const ContactInquiry = ({
                       placeholder="Your name"
                       _placeholder={{ color: "#CBD5E0" }}
                       width="387px"
+                      onChange={(event) => {
+                        setContactName(event.target.value);
+                      }}
                     />
                   </Box>
                   <Box>
@@ -160,6 +196,9 @@ const ContactInquiry = ({
                       placeholder="Email"
                       _placeholder={{ color: "#CBD5E0" }}
                       width="387px"
+                      onChange={(event) => {
+                        setReplyEmail(event.target.value);
+                      }}
                     />
                   </Box>
                   <HStack>
@@ -179,6 +218,9 @@ const ContactInquiry = ({
                           "&": {
                             color: "#CBD5E0",
                           },
+                        }}
+                        onChange={(event) => {
+                          setAgeGroup(event.target.value);
                         }}
                       >
                         {ageGroups.map((group) => {
@@ -204,6 +246,9 @@ const ContactInquiry = ({
                         placeholder="Select size"
                         _placeholder={{ color: "#CBD5E0" }}
                         width="162px"
+                        onChange={(event) => {
+                          setAudienceSize(event.target.valueAsNumber);
+                        }}
                       />
                     </Box>
                   </HStack>
@@ -255,6 +300,7 @@ const ContactInquiry = ({
                       <RadioGroup
                         onChange={(value) => {
                           setTentativeDate(value === "tentative");
+                          setPreferredDate(value === "preferred");
                         }}
                       >
                         <Stack direction="column" spacing="0px">
@@ -352,6 +398,9 @@ const ContactInquiry = ({
                     <Input
                       placeholder="Subject"
                       _placeholder={{ color: "#CBD5E0" }}
+                      onChange={(event) => {
+                        setSubject(event.target.value);
+                      }}
                     />
                   </Box>
                   <Box>
@@ -360,7 +409,7 @@ const ContactInquiry = ({
                     </Text>
                     <Textarea
                       onChange={(event) => {
-                        setMessageLength(event.target.value.length);
+                        setMessage(event.target.value);
                       }}
                       placeholder="Message"
                       _placeholder={{ color: "#CBD5E0" }}
@@ -375,7 +424,7 @@ const ContactInquiry = ({
                       fontSize="13px"
                       textColor="#A0AEC0"
                     >
-                      {messageLength}/500 characters
+                      {message.length}/500 characters
                     </Text>
                   </Box>
                   <Button
@@ -386,8 +435,7 @@ const ContactInquiry = ({
                     mt="20px"
                     alignSelf="flex-end"
                     onClick={() => {
-                      setFormView(false);
-                      // TODO: Send ContactInquiry form data.
+                      submitCreatorBooking();
                     }}
                   >
                     Submit

--- a/frontend/src/components/pages/CreatorProfile/CreatorProfile.tsx
+++ b/frontend/src/components/pages/CreatorProfile/CreatorProfile.tsx
@@ -1,3 +1,4 @@
+import { ArrowBackIcon, EmailIcon, SearchIcon } from "@chakra-ui/icons";
 import {
   Box,
   Button,
@@ -7,7 +8,6 @@ import {
   Text,
   useDisclosure,
 } from "@chakra-ui/react";
-import { ArrowBackIcon, EmailIcon, SearchIcon } from "@chakra-ui/icons";
 import React, { useEffect, useState } from "react";
 import { Link, useHistory, useParams } from "react-router-dom";
 

--- a/frontend/src/components/pages/CreatorProfile/CreatorProfile.tsx
+++ b/frontend/src/components/pages/CreatorProfile/CreatorProfile.tsx
@@ -1,5 +1,13 @@
 import { ArrowBackIcon, EmailIcon } from "@chakra-ui/icons";
-import { Box, Button, Center, Flex, Heading, Text } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  Center,
+  Flex,
+  Heading,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react";
 import React, { useEffect, useState } from "react";
 import { Link, useHistory, useParams } from "react-router-dom";
 
@@ -7,6 +15,7 @@ import CreatorAPIClient from "../../../APIClients/CreatorAPIClient";
 import background from "../../../assets/SearchResultsBackground.png";
 import { Creator } from "../../../types/CreatorTypes";
 import LoadingSpinner from "../../common/LoadingSpinner";
+import ContactInquiry from "./ContactInquiry";
 import CreatorOverview from "./CreatorOverview";
 import CreatorPublications from "./CreatorPublications";
 
@@ -18,6 +27,7 @@ const CreatorProfile = (): React.ReactElement => {
   const [currentCreator, setCurrentCreator] = useState<Creator | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const { id } = useParams<CreatorProfileParams>();
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const history = useHistory();
 
@@ -68,13 +78,23 @@ const CreatorProfile = (): React.ReactElement => {
                 <Heading as="h2" size="xl">
                   {currentCreator.firstName} {currentCreator.lastName}
                 </Heading>
-                <Button leftIcon={<EmailIcon />} variant="add" cursor="pointer">
+                <Button
+                  leftIcon={<EmailIcon />}
+                  variant="add"
+                  cursor="pointer"
+                  onClick={onOpen}
+                >
                   Contact
                 </Button>
               </Flex>
 
               <CreatorOverview currentCreator={currentCreator} />
               <CreatorPublications currentCreator={currentCreator} />
+              <ContactInquiry
+                currentCreator={currentCreator}
+                isOpen={isOpen}
+                onClose={onClose}
+              />
             </Box>
           </Center>
         </Box>

--- a/frontend/src/types/CreatorTypes.ts
+++ b/frontend/src/types/CreatorTypes.ts
@@ -73,3 +73,19 @@ export type CreatorRequest = {
   subject?: string;
   message?: string;
 };
+
+/**
+ * Type for Creator Booking Requests
+ */
+export type CreatorBookingRequest = {
+  creatorId?: number;
+  name: string;
+  email: string;
+  date: string;
+  isTentative: boolean;
+  isOneDay: boolean;
+  ageGroup: string;
+  audienceSize: number;
+  subject: string;
+  message: string;
+};


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Booker: Creator Contact Form](https://www.notion.so/uwblueprintexecs/Booker-Creator-Contact-Form-cba202d29f044821afae57b6e92ae5a7?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Display CreatorInquiry form with corresponding Creator data as a modal when a user clicks the Contact button 
* Load profile picture link, added creator full name and craft + related styling


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Access a creator using the endpoint `creators/{creator_id}` 
2. Click on the contact form
3. Run though the CreatorInquiry form flow and submit 
4. Clicking the 'x' button will display a confirmation about the exit 



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Use of useDisclosure to control the modal display of the CreatorInquiry form
* Is creator.craft representative of the creator role? 
* Added a TODO comment about where to send the CreatorInquriy form data on submit 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
