### PR TITLE
Fix empty account dropdown

### DIFF
--- a/frontend/src/components/common/NavBar.tsx
+++ b/frontend/src/components/common/NavBar.tsx
@@ -29,18 +29,6 @@ const NavBar = (): React.ReactElement => {
     onOpen: onChangePasswordModalOpen,
     onClose: onChangePasswordModalClose,
   } = useDisclosure();
-  let userFirstName = "";
-  let userLastName = "";
-  let userEmail = "";
-  if (
-    authenticatedUser &&
-    authenticatedUser.firstName &&
-    authenticatedUser.lastName
-  ) {
-    userFirstName = authenticatedUser?.firstName;
-    userLastName = authenticatedUser?.lastName;
-    userEmail = authenticatedUser.email;
-  }
 
   const onLogOutClick = async () => {
     const success = await authAPIClient.logout(authenticatedUser?.id);
@@ -127,7 +115,7 @@ const NavBar = (): React.ReactElement => {
                 cursor="default"
                 paddingTop="3px"
               >
-                {userFirstName} {userLastName}
+                {authenticatedUser?.firstName} {authenticatedUser?.lastName}
               </Text>
               <Text
                 color="#4A5568"
@@ -136,7 +124,16 @@ const NavBar = (): React.ReactElement => {
                 padding="3px 0px"
                 cursor="default"
               >
-                {userEmail}
+                {authenticatedUser?.email}
+              </Text>
+
+              <Text
+                color="#4A5568"
+                textStyle="body"
+                fontSize="sm"
+                cursor="default"
+              >
+                {authenticatedUser?.roleType}
               </Text>
 
               <MenuDivider />
@@ -151,19 +148,19 @@ const NavBar = (): React.ReactElement => {
                   >
                     Invite new admin
                   </MenuItem>
-                  <MenuItem
-                    textStyle="body"
-                    fontSize="sm"
-                    padding="3px 0px"
-                    cursor="pointer"
-                    onClick={onChangePasswordModalOpen}
-                  >
-                    Change password
-                  </MenuItem>
-
-                  <MenuDivider />
                 </div>
               )}
+              <MenuItem
+                textStyle="body"
+                fontSize="sm"
+                padding="3px 0px"
+                cursor="pointer"
+                onClick={onChangePasswordModalOpen}
+              >
+                Change password
+              </MenuItem>
+
+              <MenuDivider />
 
               <MenuItem
                 textStyle="body"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Empty Account Dropdown](https://www.notion.so/uwblueprintexecs/Empty-Account-Dropdown-0571841bd98e41a7b124f2d95414f1c3?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Removed some checks that were causing the account values to not populate
* Display email and change password option for all users instead of just admin
* Display role type for all users



<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Login with an account and click on the account button in the navigation bar

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* When newly creating an account, the user first name and last name fields will be empty since we only ask for email on signup. So, the first name and last name will not display on the account dropdown on a newly created account


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
