### PR TITLE
Fix Constant Reload Bug

### DIFF
--- a/backend/typescript/rest/creatorRoutes.ts
+++ b/backend/typescript/rest/creatorRoutes.ts
@@ -72,19 +72,15 @@ creatorRouter.get(
 );
 
 // Get users by ID. Above function does not work properly.
-creatorRouter.get(
-  "/:id",
-  isAuthorizedByRole(new Set(["Admin", "Subscriber", "Author"])),
-  async (req, res) => {
-    const { id } = req.params;
-    try {
-      const creator = await creatorService.getCreatorById(id);
-      res.status(200).json(creator);
-    } catch (e: unknown) {
-      sendErrorResponse(e, res);
-    }
-  },
-);
+creatorRouter.get("/:id", async (req, res) => {
+  const { id } = req.params;
+  try {
+    const creator = await creatorService.getCreatorById(id);
+    res.status(200).json(creator);
+  } catch (e: unknown) {
+    sendErrorResponse(e, res);
+  }
+});
 
 /* Approve users to be creators by id */
 creatorRouter.put(

--- a/frontend/src/APIClients/BaseAPIClient.ts
+++ b/frontend/src/APIClients/BaseAPIClient.ts
@@ -12,6 +12,9 @@ const baseAPIClient = axios.create({
 baseAPIClient.interceptors.request.use(async (config: AxiosRequestConfig) => {
   const newConfig = { ...config };
 
+  const currentURL = window.location.pathname.split("/");
+  const isCreatorProfilePage = currentURL.includes("creators");
+
   // if access token in header has expired, do a refresh
   const authHeaderParts = config.headers.Authorization?.split(" ");
   if (
@@ -36,7 +39,7 @@ baseAPIClient.interceptors.request.use(async (config: AxiosRequestConfig) => {
         data = res.data;
       } catch (err) {
         localStorage.removeItem(AUTHENTICATED_USER_KEY);
-        window.location.reload();
+        window.location.href = "/login";
       }
 
       const accessToken = data.accessToken || data.access_token;
@@ -47,9 +50,11 @@ baseAPIClient.interceptors.request.use(async (config: AxiosRequestConfig) => {
       );
 
       newConfig.headers.Authorization = `Bearer ${accessToken}`;
+    } else if (decodedToken === null && isCreatorProfilePage) {
+      localStorage.removeItem(AUTHENTICATED_USER_KEY); // do not redirct if url of the form https:localhost:3000/creators/1
     } else if (decodedToken === null) {
       localStorage.removeItem(AUTHENTICATED_USER_KEY);
-      window.location.reload();
+      window.location.href = "/login";
     }
   }
 

--- a/frontend/src/constants/Routes.ts
+++ b/frontend/src/constants/Routes.ts
@@ -16,6 +16,8 @@ export const CREATOR_PROFILE_LANDING = "/finish-profile";
 
 export const CREATOR_PROFILE_SETUP = "/create-creator-profile";
 
+export const CREATOR_PROFILE_OVERVIEW = "/creators/:id";
+
 export const EDIT_TEAM_PAGE = "/edit-team";
 
 export const DISPLAY_ENTITY_PAGE = "/entity";
@@ -50,4 +52,3 @@ export const SEARCH_REVIEWS_PAGE = "/magazine/search_results";
 export const PREVIEW_REVIEW_TEST = "/test/preview-review";
 export const SEARCH_BOX = "/test/search-box";
 export const FILTER_BOX = "/test/filter";
-export const CREATOR_PROFILE_OVERVIEW = "/creators/:id";


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Constant reload ](https://www.notion.so/uwblueprintexecs/Constant-reload-dd396e31688d445c8f51ac5c8105b0ef)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Removed auth check on the creator route for GET by ID
* Reworked BaseAPIClient to not redirect if there is no jwt token on creator/id page. Any other page should be redirected to /login if the jwt token is expired.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run docker-compose up
2. Double check database is seeded
3. Without signing in, go to http://localhost:3000/creators/1
4. Check if you can access the page and all the data loads


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Is it safe to remove the authorization check for the GET by ID route?

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
