### PR TITLE
replace import image field to bookmodal vs image URL

### DIFF
--- a/frontend/src/components/pages/CreateReview/BookModal.tsx
+++ b/frontend/src/components/pages/CreateReview/BookModal.tsx
@@ -469,7 +469,7 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
             <GridItem>
               <Stack spacing={4} direction="column">
                 <AddProfilePicture
-                  name="bookCover"
+                  name="Book Cover"
                   value={coverImage}
                   field="profilePictureLink"
                   mode="BookModal"

--- a/frontend/src/components/pages/CreateReview/BookModal.tsx
+++ b/frontend/src/components/pages/CreateReview/BookModal.tsx
@@ -21,6 +21,7 @@ import genreAPIClient from "../../../APIClients/GenreAPIClient";
 import tagAPIClient from "../../../APIClients/TagAPIClient";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { BookFormats } from "../../../constants/Enums";
+import AddProfilePictureMode from "../../../types/Types"
 import {
   Author,
   Book,
@@ -472,7 +473,7 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
                   name="Book Cover"
                   value={coverImage}
                   field="profilePictureLink"
-                  mode="BookModal"
+                  mode={AddProfilePictureMode.bookModal}
                   setInputField={setCoverImage}
                   required
                 />

--- a/frontend/src/components/pages/CreateReview/BookModal.tsx
+++ b/frontend/src/components/pages/CreateReview/BookModal.tsx
@@ -476,15 +476,6 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
                   setInputField={setCoverImage}
                   required
                 />
-                <AddStringInput
-                  id="bookCover"
-                  label="Book Cover"
-                  name="bookCover"
-                  placeholder="Image link here"
-                  required
-                  inputFieldValue={coverImage}
-                  setInputField={setCoverImage}
-                />
                 <AddMultiSelect
                   id="genre"
                   label="Genres"

--- a/frontend/src/components/pages/CreateReview/BookModal.tsx
+++ b/frontend/src/components/pages/CreateReview/BookModal.tsx
@@ -36,6 +36,7 @@ import AddSelect from "./AddSelect";
 import AddSelectList from "./AddSelectList";
 import AddStringInput from "./AddStringInput";
 import AddStringInputList from "./AddStringInputList";
+import AddProfilePicture from "../CreatorProfile/AddProfilePictureField";
 
 /**
  * Interface defining props for BookModal component
@@ -467,6 +468,14 @@ const BookModal = (props: BookModalProps): React.ReactElement => {
             </GridItem>
             <GridItem>
               <Stack spacing={4} direction="column">
+                <AddProfilePicture
+                  name="bookCover"
+                  value={coverImage}
+                  field="profilePictureLink"
+                  mode="BookModal"
+                  setInputField={setCoverImage}
+                  required
+                />
                 <AddStringInput
                   id="bookCover"
                   label="Book Cover"

--- a/frontend/src/components/pages/CreatorProfile/AddProfilePictureField.tsx
+++ b/frontend/src/components/pages/CreatorProfile/AddProfilePictureField.tsx
@@ -15,6 +15,7 @@ import {
   CreatorProfile,
   CreatorProfileProps,
 } from "../../../types/CreatorProfileTypes";
+import AddProfilePictureMode from "../../../types/Types"
 
 interface AddProfilePictureProps {
   name: string;
@@ -23,7 +24,7 @@ interface AddProfilePictureProps {
   error?: boolean;
   required?: boolean;
   setInputField: (s: string) => void;
-  mode? : string;
+  mode? : AddProfilePictureMode;
 }
 
 const AddProfilePicture = ({
@@ -33,7 +34,7 @@ const AddProfilePicture = ({
   value,
   required = true,
   setInputField,
-  mode = ""
+  mode
 }: AddProfilePictureProps): React.ReactElement => {
   const { creatorProfile, setCreatorProfile } = useContext(
     CreatorProfileContext,
@@ -58,22 +59,30 @@ const AddProfilePicture = ({
     if (profilePic) {
       const Url = await uploadImage(profilePic);
 
-      if (mode === "CreatorProfile") {
-        const creatorProfileObj: CreatorProfile = {
-          ...creatorProfile,
-        };
-        creatorProfileObj[field] = Url;
-        setFileSize(profilePic.size.toString());
-        setFileName(profilePic.name);
-        localStorage.setItem("fileSize", profilePic.size.toString());
-        localStorage.setItem("fileName", profilePic.name);
-        setCreatorProfile(creatorProfileObj);
-      } else if (mode === "BookModal") {
-        setInputField(Url)
-        setFileSize(profilePic.size.toString());
-        setFileName(profilePic.name);
-        localStorage.setItem("fileSize", profilePic.size.toString());
-        localStorage.setItem("fileName", profilePic.name);
+      switch (mode) {
+        case AddProfilePictureMode.creatorProfile: {
+          const creatorProfileObj: CreatorProfile = {
+            ...creatorProfile,
+          };
+          creatorProfileObj[field] = Url;
+          setFileSize(profilePic.size.toString());
+          setFileName(profilePic.name);
+          localStorage.setItem("fileSize", profilePic.size.toString());
+          localStorage.setItem("fileName", profilePic.name);
+          setCreatorProfile(creatorProfileObj);
+          break;
+        }
+        case AddProfilePictureMode.bookModal: {
+          setInputField(Url)
+          setFileSize(profilePic.size.toString());
+          setFileName(profilePic.name);
+          localStorage.setItem("fileSize", profilePic.size.toString());
+          localStorage.setItem("fileName", profilePic.name);
+          break;
+        }
+        default: {
+          break;
+        }
       }
     }
     

--- a/frontend/src/components/pages/CreatorProfile/AddProfilePictureField.tsx
+++ b/frontend/src/components/pages/CreatorProfile/AddProfilePictureField.tsx
@@ -22,6 +22,8 @@ interface AddProfilePictureProps {
   field: CreatorProfileProps;
   error?: boolean;
   required?: boolean;
+  setInputField: (s: string) => void;
+  mode? : string;
 }
 
 const AddProfilePicture = ({
@@ -30,6 +32,8 @@ const AddProfilePicture = ({
   error = false,
   value,
   required = true,
+  setInputField,
+  mode = ""
 }: AddProfilePictureProps): React.ReactElement => {
   const { creatorProfile, setCreatorProfile } = useContext(
     CreatorProfileContext,
@@ -49,20 +53,30 @@ const AddProfilePicture = ({
   };
 
   const handleOnChange = async () => {
+
     const profilePic = profilePicFile?.current?.files?.[0];
     if (profilePic) {
       const Url = await uploadImage(profilePic);
 
-      const creatorProfileObj: CreatorProfile = {
-        ...creatorProfile,
-      };
-      creatorProfileObj[field] = Url;
-      setFileSize(profilePic.size.toString());
-      setFileName(profilePic.name);
-      localStorage.setItem("fileSize", profilePic.size.toString());
-      localStorage.setItem("fileName", profilePic.name);
-      setCreatorProfile(creatorProfileObj);
+      if (mode === "CreatorProfile") {
+        const creatorProfileObj: CreatorProfile = {
+          ...creatorProfile,
+        };
+        creatorProfileObj[field] = Url;
+        setFileSize(profilePic.size.toString());
+        setFileName(profilePic.name);
+        localStorage.setItem("fileSize", profilePic.size.toString());
+        localStorage.setItem("fileName", profilePic.name);
+        setCreatorProfile(creatorProfileObj);
+      } else if (mode === "BookModal") {
+        setInputField(Url)
+        setFileSize(profilePic.size.toString());
+        setFileName(profilePic.name);
+        localStorage.setItem("fileSize", profilePic.size.toString());
+        localStorage.setItem("fileName", profilePic.name);
+      }
     }
+    
   };
 
   return (
@@ -159,7 +173,5 @@ const AddProfilePicture = ({
     </FormControl>
   );
 };
-
-// TODO: Keep the state once you leave to a different step
 
 export default AddProfilePicture;

--- a/frontend/src/components/pages/CreatorProfile/GeneralInfoForm.tsx
+++ b/frontend/src/components/pages/CreatorProfile/GeneralInfoForm.tsx
@@ -139,6 +139,9 @@ const GeneraInfoForm = ({ submitted }: GeneraInfoProps): React.ReactElement => {
           value={creatorProfile?.profilePictureLink}
           field="profilePictureLink"
           error={submitted}
+          setInputField={()=>{}}
+          mode="CreatorProfile"
+          required
         />
       </div>
     </Flex>

--- a/frontend/src/components/pages/CreatorProfile/GeneralInfoForm.tsx
+++ b/frontend/src/components/pages/CreatorProfile/GeneralInfoForm.tsx
@@ -97,6 +97,7 @@ const GeneraInfoForm = ({ submitted }: GeneraInfoProps): React.ReactElement => {
           options={craftOptions}
           placeholder="Select or type to add your own option"
           setOptions={setCraftOptions}
+          maxWidth="33%"
           optionsSelected={crafts}
           setOptionsSelected={(options: Option[]) => setCrafts(options)}
           allowMultiSelectOption
@@ -110,6 +111,7 @@ const GeneraInfoForm = ({ submitted }: GeneraInfoProps): React.ReactElement => {
           options={genreOptions}
           placeholder="Select or type to add your own option"
           setOptions={setGenreOptions}
+          maxWidth="33%"
           optionsSelected={genres}
           setOptionsSelected={(options: Option[]) => setGenres(options)}
           allowMultiSelectOption
@@ -123,13 +125,13 @@ const GeneraInfoForm = ({ submitted }: GeneraInfoProps): React.ReactElement => {
           value={creatorProfile?.website}
           field="website"
           required={false}
-          width="100%"
+          width="33%"
           error={submitted}
         />
         <RichTextEditorField
           name="Bio"
           placeholder="Here's where you can briefly describe who you are as a creator!"
-          value={creatorProfile?.bio}
+        value={creatorProfile?.bio}
           field="bio"
           error={submitted}
           charLimit={500}

--- a/frontend/src/components/pages/CreatorProfile/GeneralInfoForm.tsx
+++ b/frontend/src/components/pages/CreatorProfile/GeneralInfoForm.tsx
@@ -7,6 +7,7 @@ import AddMultiSelect from "../CreateReview/AddMultiSelect";
 import AddProfilePictureField from "./AddProfilePictureField";
 import CreatorInputField from "./CreatorInputField";
 import RichTextEditorField from "./RichTextEditorField";
+import AddProfilePictureMode from "../../../types/Types"
 
 interface GeneraInfoProps {
   submitted: boolean;
@@ -142,7 +143,7 @@ const GeneraInfoForm = ({ submitted }: GeneraInfoProps): React.ReactElement => {
           field="profilePictureLink"
           error={submitted}
           setInputField={()=>{}}
-          mode="CreatorProfile"
+          mode={AddProfilePictureMode.creatorProfile}
           required
         />
       </div>

--- a/frontend/src/components/pages/CreatorProfile/RichTextEditorField.tsx
+++ b/frontend/src/components/pages/CreatorProfile/RichTextEditorField.tsx
@@ -69,7 +69,7 @@ const AddRichTextEditor = ({
     <FormControl
       isRequired={required}
       isInvalid={required && error && value === ""}
-      width="100%"
+      width="40%"
     >
       <FormLabel mb="1" mt="3">
         {name}

--- a/frontend/src/types/Types.ts
+++ b/frontend/src/types/Types.ts
@@ -1,0 +1,10 @@
+
+/**
+ * enum for the mode selector used by AddProfilePictureField component
+ */
+enum AddProfilePictureMode {
+    creatorProfile,
+    bookModal
+}
+
+export default AddProfilePictureMode


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Image Upload for Books](https://www.notion.so/uwblueprintexecs/16fb020b93f641c8b384f76a1b3c769e?v=0f0df1f1b7074d2cb19b7eb7652d7d04&p=c9cc366e6a1a463daad7625e3d42d8e8&pm=c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a mode selector for the addprofilepic component to support bookmodal for this component
* Replaced the book cover URL text component with addprofilepic


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Signup as an Admin in `localhost:3000/signup`
2. Go to `localhost:3000/create-review`
3. Click the plus sign to add a book cover and upload an image
4. Fixed styling errors related to width of component in `GeneralInfoForm`


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Better way to build the mode selector
* Does the image upload properly?


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have run docker-compose up and my project compiled
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
