### PR TITLE
Add 12+ category to magazine reviews

### DIFF
--- a/frontend/src/components/pages/MagazineReview/MagazineReview.tsx
+++ b/frontend/src/components/pages/MagazineReview/MagazineReview.tsx
@@ -22,6 +22,9 @@ const MagazineReview = (): React.ReactElement => {
   const [zeroToThreeReviews, setZeroToThreeReviews] = useState<Review[]>([]);
   const [fourToEightReviews, setFourToEightReviews] = useState<Review[]>([]);
   const [nineToTwelveReviews, setNineToTwelveReviews] = useState<Review[]>([]);
+  const [twelveAndOverReviews, setTwelveAndOverReviews] = useState<Review[]>(
+    [],
+  );
   const [featuredReviews, setFeaturedReviews] = useState<Review[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
 
@@ -44,23 +47,31 @@ const MagazineReview = (): React.ReactElement => {
         setFeaturedReviews(mapReviewResponseToReview(reviewResponse.reviews));
       });
     reviewAPIClient
-      .getReviews(undefined, 5, 0, 0, 3)
+      .getReviews(undefined, 4, 0, 0, 3)
       .then((reviewResponse: PaginatedReviewResponse) => {
         setZeroToThreeReviews(
           mapReviewResponseToReview(reviewResponse.reviews),
         );
       });
     reviewAPIClient
-      .getReviews(undefined, 5, 0, 4, 8)
+      .getReviews(undefined, 4, 0, 4, 8)
       .then((reviewResponse: PaginatedReviewResponse) => {
         setFourToEightReviews(
           mapReviewResponseToReview(reviewResponse.reviews),
         );
       });
     reviewAPIClient
-      .getReviews(undefined, 5, 0, 9, 12)
+      .getReviews(undefined, 4, 0, 9, 12)
       .then((reviewResponse: PaginatedReviewResponse) => {
         setNineToTwelveReviews(
+          mapReviewResponseToReview(reviewResponse.reviews),
+        );
+        setLoading(false);
+      });
+    reviewAPIClient
+      .getReviews(undefined, 4, 0, 12, 100)
+      .then((reviewResponse: PaginatedReviewResponse) => {
+        setTwelveAndOverReviews(
           mapReviewResponseToReview(reviewResponse.reviews),
         );
         setLoading(false);
@@ -77,7 +88,7 @@ const MagazineReview = (): React.ReactElement => {
         bgRepeat="no-repeat"
         backgroundSize="cover"
         backgroundAttachment="scroll"
-        bgPosition="0 -120px"
+        bgPosition="0"
       >
         <VStack>
           {displayBlurb && (
@@ -128,6 +139,11 @@ const MagazineReview = (): React.ReactElement => {
                   name="Age 9 - 12"
                   link="/magazine/search_results/?minAge=9&maxAge=12"
                   reviews={nineToTwelveReviews}
+                />
+                <CategoryReviews
+                  name="Age 12+"
+                  link="/magazine/search_results/?minAge=12&maxAge=100"
+                  reviews={twelveAndOverReviews}
                 />
               </Box>
             </Flex>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[12+ Category](https://www.notion.so/uwblueprintexecs/12-Category-263b405b65c6435ebcad563003aea3d8?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added a 12+ category for the magazine review landing page
* Updated background position so bottom of page isn't blank
* Updated reviews per section to fit Figma + page width


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Open Magazine Directory tab and scroll to bottom


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Is there anywhere else this needs to be updated? Confirmed categories exist for magazine filtering + creator filtering
* Noticed the magazine filter uses 12-18 while creator filter uses 12-100 should one of these be chosen for consistency?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
