### PR TITLE
[Bug]: Fix userId param

### DIFF
--- a/backend/typescript/rest/creatorRoutes.ts
+++ b/backend/typescript/rest/creatorRoutes.ts
@@ -155,7 +155,9 @@ creatorRouter.post(
     try {
       if (req.body.isApproved) throw new Error("invalid creator");
       // Only allow creation without any data
-      const result = await creatorService.createCreator(req.body.userId);
+      const result = await creatorService.createCreator(
+        parseInt(req.body.userId, 10),
+      );
 
       res.status(200).json(result);
     } catch (e: unknown) {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Save and exit fails on staging](https://www.notion.so/uwblueprintexecs/Save-and-exit-fails-on-staging-ac1659f6ad08492f90e22cb1550b39b5?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Bug was because numeric user_id was being sent as a string - this parses it into an int before looking up the creator
* Tested locally with new creator and cleared database and saved successfully


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create new creator profile + try to save 


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
