### PR TITLE
[Bug]: Remove subscription notice for admins

### DIFF
--- a/frontend/src/components/pages/MagazineReview/MagazineReview.tsx
+++ b/frontend/src/components/pages/MagazineReview/MagazineReview.tsx
@@ -28,6 +28,7 @@ import React, {
 import reviewAPIClient from "../../../APIClients/ReviewAPIClient";
 import UsersAPIClient from "../../../APIClients/UsersAPIClient";
 import background from "../../../assets/home-bg.png";
+import { UserRole } from "../../../constants/Enums";
 import AuthContext from "../../../contexts/AuthContext";
 import { AuthenticatedUser } from "../../../types/AuthTypes";
 import { PaginatedReviewResponse, Review } from "../../../types/ReviewTypes";
@@ -48,6 +49,7 @@ const MagazineReview = (): React.ReactElement => {
   const [loading, setLoading] = useState<boolean>(false);
   const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);
   const expiryDate = useRef(authenticatedUser?.subscriptionExpiresOn);
+  const isSubscriber = authenticatedUser?.roleType === UserRole.Subscriber;
 
   const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -69,7 +71,7 @@ const MagazineReview = (): React.ReactElement => {
     const subscriptionExpiryDate = new Date(
       Moment(expiryDate.current).format("LLLL"),
     );
-    if (subscriptionExpiryDate < new Date(Date.now())) {
+    if (subscriptionExpiryDate < new Date(Date.now()) && isSubscriber) {
       onOpen();
     } else {
       onClose();
@@ -93,7 +95,7 @@ const MagazineReview = (): React.ReactElement => {
 
   useEffect(() => {
     verifySubscriptionExpiry();
-  }, [verifySubscriptionExpiry]);
+  }, []);
 
   // get featured reviews on magazine home page
   useEffect(() => {


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Only subscribers should see the prompt to renew their subscription](https://www.notion.so/uwblueprintexecs/Only-subscribers-should-see-the-prompt-to-renew-their-subscription-393544d5b05e46ac822f557c9ed5cc0d?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added isSubscriber flag to determine whether the modal should pop up
* Removed dependency from useEffect that was causing infinite requests (and confirmed modal still pops up without the dependency) 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Login as admin and modal shouldn't pop up anymore


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
