### PR TITLE
[Fix]: link creator dashboard to profile

### DIFF
--- a/frontend/src/components/pages/AdminDashboard/AdminCreatorProfiles.tsx
+++ b/frontend/src/components/pages/AdminDashboard/AdminCreatorProfiles.tsx
@@ -180,6 +180,19 @@ const AdminCreatorProfiles = (): React.ReactElement => {
         label: "Creator",
         options: {
           setCellProps: () => ({ style: { minWidth: "220px" } }),
+          customBodyRender: (value, tableMeta) => {
+            return (
+              <Button
+                pl={0}
+                variant="ghost"
+                onClick={() =>
+                  history.push(`/creators/${tableMeta.rowData[0]}`)
+                }
+              >
+                {value}
+              </Button>
+            );
+          },
         },
       },
       {
@@ -299,6 +312,7 @@ const AdminCreatorProfiles = (): React.ReactElement => {
         });
         currColumn.options.customHeadLabelRender = headLabelRenderFunction;
         if (
+          currColumn.name !== "name" &&
           currColumn.name !== "authors" &&
           currColumn.name !== "status" &&
           currColumn.name !== "actions"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Link Admin Dashboard to Creator Profile](https://www.notion.so/uwblueprintexecs/Link-Admin-Dashboard-to-Creator-Profile-bebe3cd1c01d4c7a918aa6b19f7a031f?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added custom render for creator name into button that links to profile


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Navigate to creator page on admin dashboard + click on creator name


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
