### PR TITLE
add createdAt to api response

### DIFF
--- a/backend/typescript/services/implementations/creatorService.ts
+++ b/backend/typescript/services/implementations/creatorService.ts
@@ -135,6 +135,7 @@ class CreatorService implements ICreatorService {
           publications: creator.publications,
           presentations: creator.presentations,
           isReadyForReview: creator.isReadyForReview,
+          createdAt: creator.createdAt,
         }))
         .filter(
           (creator) =>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Display date section properly in admin dashboard](https://www.notion.so/uwblueprintexecs/Display-date-section-properly-in-admin-dashboard-5c057337488f4b7e91947454c7079311?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* The getCreators function wasn't returning the createdAt field so it was undefined and not showing up


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to the creator profile admin dashboard and there should be a date now


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have run docker-compose up and my project compiled
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
