### PR TITLE
Hide publications and presentations when none exist

### DIFF
--- a/frontend/src/components/pages/CreatorProfile/CreatorPresentations.tsx
+++ b/frontend/src/components/pages/CreatorProfile/CreatorPresentations.tsx
@@ -44,7 +44,7 @@ const CreatorPresentations = ({
   const READINGS_NAME = "Readings";
   const WORKSHOPS_NAME = "Workshops";
 
-  return (
+  return (presentations.length ?? 0) > 0 ? (
     <Flex mb="16px" direction="column">
       <Text textStyle="heading" fontSize="30px" fontWeight="bold">
         Presentations
@@ -141,6 +141,8 @@ const CreatorPresentations = ({
         );
       })}
     </Flex>
+  ) : (
+    <></>
   );
 };
 

--- a/frontend/src/components/pages/CreatorProfile/CreatorPublications.tsx
+++ b/frontend/src/components/pages/CreatorProfile/CreatorPublications.tsx
@@ -45,7 +45,7 @@ const CreatorPublications = ({
     );
   };
 
-  return (
+  return (currentCreator.publications?.length ?? 0) > 0 ? (
     <>
       <Text
         textStyle="heading"
@@ -80,6 +80,8 @@ const CreatorPublications = ({
         </Flex>
       </Flex>
     </>
+  ) : (
+    <></>
   );
 };
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Hide publications + presentations section if there’s no publications/presentations](https://www.notion.so/uwblueprintexecs/Hide-publications-presentations-section-if-there-s-no-publications-presentations-03b3dc77c7704e22b1e6ba0e23fbbe68)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Publications and presentations each conditionally render now based on whether there are actually any publications or presentations respectively


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Go to creator profile


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have run docker-compose up and my project compiled
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
