### PR TITLE
add carousel for publication images

### DIFF
--- a/frontend/src/components/pages/CreatorProfile/Carousel.tsx
+++ b/frontend/src/components/pages/CreatorProfile/Carousel.tsx
@@ -1,6 +1,6 @@
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 
-import { Box, Flex, IconButton, Image } from "@chakra-ui/react";
+import { IconButton, Image } from "@chakra-ui/react";
 import { makeStyles } from "@material-ui/core";
 import React from "react";
 import { FcNext, FcPrevious } from "react-icons/fc";

--- a/frontend/src/components/pages/CreatorProfile/Carousel.tsx
+++ b/frontend/src/components/pages/CreatorProfile/Carousel.tsx
@@ -1,6 +1,6 @@
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 
-import { Flex, IconButton, Image } from "@chakra-ui/react";
+import { Box, Flex, IconButton, Image } from "@chakra-ui/react";
 import { makeStyles } from "@material-ui/core";
 import React from "react";
 import { FcNext, FcPrevious } from "react-icons/fc";
@@ -80,14 +80,15 @@ const Carousel = ({ images }: CarouselProps): React.ReactElement => {
         }
       >
         {images.map((URL, index) => (
-          <Flex key={index} mr="16px">
-            <Image
-              alt={`media_gallery_${index}`}
-              src={URL}
-              key={index}
-              height="230px"
-            />
-          </Flex>
+          <Image
+            alt={`media_gallery_${index}`}
+            src={URL}
+            key={index}
+            height="250px"
+            maxWidth="175px"
+            objectFit="contain"
+            mr="-30px"
+          />
         ))}
       </ResponsiveCarousel>
     </div>

--- a/frontend/src/components/pages/CreatorProfile/CreatorProfile.tsx
+++ b/frontend/src/components/pages/CreatorProfile/CreatorProfile.tsx
@@ -77,7 +77,8 @@ const CreatorProfile = (): React.ReactElement => {
           bgRepeat="no-repeat"
           backgroundSize="cover"
           backgroundAttachment="scroll"
-          bgPosition="0 -120px"
+          bgPosition="0"
+          paddingBottom="36"
         >
           <Center>
             <Box w="80%">

--- a/frontend/src/components/pages/CreatorProfile/CreatorPublications.tsx
+++ b/frontend/src/components/pages/CreatorProfile/CreatorPublications.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import rectangle from "../../../assets/rectangle.png";
 import * as Routes from "../../../constants/Routes";
 import { Creator, Publication } from "../../../types/CreatorTypes";
+import Carousel from "./Carousel";
 
 interface CreatorPublicationsProps {
   currentCreator: Creator;
@@ -37,8 +38,9 @@ const CreatorPublications = ({
   const bookCoverDisplay = (bookCoverImageURL: string, index: number) => {
     return (
       <Image
-        minWidth="175px"
-        height="auto"
+        maxHeight="250px"
+        marginLeft="25px"
+        width="auto"
         src={bookCoverImageURL}
         key={index}
       />
@@ -56,7 +58,7 @@ const CreatorPublications = ({
       >
         Publications
       </Text>
-      <Flex>
+      <Flex direction={{ base: "column", lg: "row" }}>
         <Box flex="2">
           {currentCreator.publications
             ?.slice(0, 3)
@@ -72,10 +74,16 @@ const CreatorPublications = ({
           </Link>
         </Box>
         <Flex flex="4" paddingLeft="50px">
-          {currentCreator.bookCovers
-            ?.slice(0, 3)
-            .map((bookCoverImageURL: string, index: number) =>
-              bookCoverDisplay(bookCoverImageURL, index),
+          {currentCreator.bookCovers &&
+            currentCreator.bookCovers.length <= 3 &&
+            currentCreator.bookCovers
+              ?.slice(0, 3)
+              .map((bookCoverImageURL: string, index: number) =>
+                bookCoverDisplay(bookCoverImageURL, index),
+              )}
+          {currentCreator.bookCovers &&
+            currentCreator.bookCovers.length > 3 && (
+              <Carousel images={currentCreator.bookCovers || []} />
             )}
         </Flex>
       </Flex>


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Image to carousel in publications](https://www.notion.so/uwblueprintexecs/Image-to-carousel-in-publications-ba4ea61368cd44e2b65c0dff4cd91d97?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added carousel for images if # of images > 3 similar to publication data display


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Create a creator with > 3 images
2. Submit + approve them
3. Visit creator directory page


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have run docker-compose up and my project compiled
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
