### PR TITLE
[Fix]: Add expired modal for creator flow

### DIFF
--- a/frontend/src/components/pages/CreatorProfile/CreatorProfileForm.tsx
+++ b/frontend/src/components/pages/CreatorProfile/CreatorProfileForm.tsx
@@ -4,6 +4,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { Link, useHistory, useLocation } from "react-router-dom";
 
 import CreatorAPIClient from "../../../APIClients/CreatorAPIClient";
+import { UserRole } from "../../../constants/Enums";
 import { CREATOR_PROFILE_LANDING } from "../../../constants/Routes";
 import AuthContext from "../../../contexts/AuthContext";
 import CreatorProfileContext from "../../../contexts/CreatorProfileContext";
@@ -12,6 +13,7 @@ import {
   CreatorProfileFormProps,
 } from "../../../types/CreatorProfileTypes";
 import LoadingSpinner from "../../common/LoadingSpinner";
+import SubscriptionExpireModal from "../Subscription/SubscriptionExpireModal";
 import AvailabilityForm from "./AvailabilityForm";
 import ContactInfoForm from "./ContactInfoForm";
 import CreatorProfileNav from "./CreatorProfileNav";
@@ -279,6 +281,7 @@ const CreatorProfileForm = (): React.ReactElement => {
             </CreatorProfileContext.Provider>
           )}
         </Flex>
+        <SubscriptionExpireModal targetUser={UserRole.Creator} />
       </Flex>
     </>
   );

--- a/frontend/src/components/pages/Subscription/SubscriptionExpireModal.tsx
+++ b/frontend/src/components/pages/Subscription/SubscriptionExpireModal.tsx
@@ -1,0 +1,85 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  useDisclosure,
+} from "@chakra-ui/react";
+import Moment from "moment";
+import React, { useCallback, useContext, useEffect, useRef } from "react";
+
+import UsersAPIClient from "../../../APIClients/UsersAPIClient";
+import { UserRole } from "../../../constants/Enums";
+import AuthContext from "../../../contexts/AuthContext";
+import { AuthenticatedUser } from "../../../types/AuthTypes";
+
+interface SubscriptionModalProps {
+  targetUser: UserRole;
+}
+
+const SubscriptionExpireModal = ({
+  targetUser,
+}: SubscriptionModalProps): React.ReactElement => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);
+  const expiryDate = useRef(authenticatedUser?.subscriptionExpiresOn);
+  const isTargetUser = authenticatedUser?.roleType === targetUser;
+
+  const onClick = () => {
+    window.location.href = `${process.env.REACT_APP_GIVECLOUD_URL}`;
+  };
+  const checkUserSubscriptionExpiry = useCallback(async () => {
+    // Convert the PostgresSQL date to a JavaScript Date object
+    const subscriptionExpiryDate = new Date(
+      Moment(expiryDate.current).format("LLLL"),
+    );
+    if (subscriptionExpiryDate < new Date(Date.now()) && isTargetUser) {
+      onOpen();
+    } else {
+      onClose();
+    }
+  }, [onClose, onOpen]);
+
+  const verifySubscriptionExpiry = useCallback(async () => {
+    if (authenticatedUser) {
+      const updatedUser: AuthenticatedUser =
+        await UsersAPIClient.getUserByEmail(authenticatedUser?.email);
+      if (updatedUser) {
+        expiryDate.current = updatedUser.subscriptionExpiresOn;
+        setAuthenticatedUser({
+          ...authenticatedUser,
+          subscriptionExpiresOn: updatedUser.subscriptionExpiresOn,
+        });
+        checkUserSubscriptionExpiry();
+      }
+    }
+  }, [authenticatedUser, checkUserSubscriptionExpiry, setAuthenticatedUser]);
+
+  useEffect(() => {
+    verifySubscriptionExpiry();
+  }, []);
+
+  return (
+    <Modal isOpen={isOpen} onClose={() => {}}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>User Subscription Expired</ModalHeader>
+        <ModalBody>
+          Your subscription to the Canadian Children&apos;s Book Centre has
+          expired. Please click on the button below and follow the steps to
+          renew your account
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="submit" type="submit" onClick={onClick}>
+            Renew Subscription
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default SubscriptionExpireModal;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Block creators if their subscription is expired](https://www.notion.so/uwblueprintexecs/Block-creators-if-their-subscription-is-expired-a589552dbf3e414c955888cdf7685013?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created new SubscriptionExpireModal component using the logic from the MagazineReview component with a prop to determine which user is affected
* Implemented this in MagazineReview for subscribers and CreatorProfileForm for creators 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Login in as creator with expired subscription and visit `/create-creator-profile`


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have run docker-compose up and my project compiled
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
